### PR TITLE
Feature: adding/editing concepts

### DIFF
--- a/LinkedIdeas.xcodeproj/project.pbxproj
+++ b/LinkedIdeas.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		9B2F1DC01BE7CFE80090CC18 /* LinkedIdeasUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2F1DBF1BE7CFE80090CC18 /* LinkedIdeasUITests.swift */; };
 		9B2F1DCE1BE7D3990090CC18 /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2F1DCD1BE7D3990090CC18 /* CanvasView.swift */; };
 		9BD2C14E1BEE6F9F00CD3C2F /* ConceptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD2C14D1BEE6F9F00CD3C2F /* ConceptView.swift */; };
+		9BDDE7391BEF9157000AAD44 /* Concept.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDDE7381BEF9157000AAD44 /* Concept.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +52,7 @@
 		9B2F1DC11BE7CFE80090CC18 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9B2F1DCD1BE7D3990090CC18 /* CanvasView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
 		9BD2C14D1BEE6F9F00CD3C2F /* ConceptView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConceptView.swift; sourceTree = "<group>"; };
+		9BDDE7381BEF9157000AAD44 /* Concept.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Concept.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +111,7 @@
 				9B2F1DAB1BE7CFE80090CC18 /* Info.plist */,
 				9B2F1DCD1BE7D3990090CC18 /* CanvasView.swift */,
 				9BD2C14D1BEE6F9F00CD3C2F /* ConceptView.swift */,
+				9BDDE7381BEF9157000AAD44 /* Concept.swift */,
 			);
 			path = LinkedIdeas;
 			sourceTree = "<group>";
@@ -266,6 +269,7 @@
 				9B2F1DA01BE7CFE70090CC18 /* AppDelegate.swift in Sources */,
 				9B2F1DCE1BE7D3990090CC18 /* CanvasView.swift in Sources */,
 				9BD2C14E1BEE6F9F00CD3C2F /* ConceptView.swift in Sources */,
+				9BDDE7391BEF9157000AAD44 /* Concept.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LinkedIdeas.xcodeproj/project.pbxproj
+++ b/LinkedIdeas.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		9B2F1DB51BE7CFE80090CC18 /* LinkedIdeasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2F1DB41BE7CFE80090CC18 /* LinkedIdeasTests.swift */; };
 		9B2F1DC01BE7CFE80090CC18 /* LinkedIdeasUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2F1DBF1BE7CFE80090CC18 /* LinkedIdeasUITests.swift */; };
 		9B2F1DCE1BE7D3990090CC18 /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2F1DCD1BE7D3990090CC18 /* CanvasView.swift */; };
+		9BD2C14E1BEE6F9F00CD3C2F /* ConceptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD2C14D1BEE6F9F00CD3C2F /* ConceptView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +50,7 @@
 		9B2F1DBF1BE7CFE80090CC18 /* LinkedIdeasUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedIdeasUITests.swift; sourceTree = "<group>"; };
 		9B2F1DC11BE7CFE80090CC18 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9B2F1DCD1BE7D3990090CC18 /* CanvasView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
+		9BD2C14D1BEE6F9F00CD3C2F /* ConceptView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConceptView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +108,7 @@
 				9B2F1DA81BE7CFE80090CC18 /* MainMenu.xib */,
 				9B2F1DAB1BE7CFE80090CC18 /* Info.plist */,
 				9B2F1DCD1BE7D3990090CC18 /* CanvasView.swift */,
+				9BD2C14D1BEE6F9F00CD3C2F /* ConceptView.swift */,
 			);
 			path = LinkedIdeas;
 			sourceTree = "<group>";
@@ -262,6 +265,7 @@
 				9B2F1DA21BE7CFE70090CC18 /* Document.swift in Sources */,
 				9B2F1DA01BE7CFE70090CC18 /* AppDelegate.swift in Sources */,
 				9B2F1DCE1BE7D3990090CC18 /* CanvasView.swift in Sources */,
+				9BD2C14E1BEE6F9F00CD3C2F /* ConceptView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LinkedIdeas/Base.lproj/Document.xib
+++ b/LinkedIdeas/Base.lproj/Document.xib
@@ -17,7 +17,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="133" y="235" width="507" height="413"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <value key="minSize" type="size" width="94" height="86"/>
             <view key="contentView" id="gIp-Ho-8D9">
                 <rect key="frame" x="0.0" y="0.0" width="507" height="413"/>

--- a/LinkedIdeas/Base.lproj/Document.xib
+++ b/LinkedIdeas/Base.lproj/Document.xib
@@ -17,7 +17,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="133" y="235" width="507" height="413"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <value key="minSize" type="size" width="94" height="86"/>
             <view key="contentView" id="gIp-Ho-8D9">
                 <rect key="frame" x="0.0" y="0.0" width="507" height="413"/>

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -13,11 +13,12 @@ protocol CanvasViewDelegate {
   func singleClick(event:NSEvent)
 }
 
-class CanvasView: NSView {
+class CanvasView: NSControl {
   
   var delegate: CanvasViewDelegate?
   var concepts = [Concept]() {
     didSet {
+      sprint("concepts length: \(concepts.count)")
       needsDisplay = true
     }
   }
@@ -35,7 +36,11 @@ class CanvasView: NSView {
         let conceptView = ConceptView(frame: concept.rect)
         conceptView.concept = concept
         concept.added = true
+        concept.editing = true
         addSubview(conceptView)
+        conceptView.canvas = self
+      } else {
+        concept.editing = false
       }
     }
   }
@@ -44,6 +49,19 @@ class CanvasView: NSView {
     delegate?.singleClick(theEvent)
   }
   
+  
+  func removeConcept(concept: Concept) {
+    sprint("removing concept \(concept.identifier)")
+    let index = concepts.indexOf({ $0.identifier == concept.identifier })
+    if let index = index {
+      sprint("remove concept")
+      concepts.removeAtIndex(index)
+    } else {
+      sprint("concept not found")
+    }
+  }
+  
+}
 
 extension NSView {
   func sprint(message: String) {

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -30,13 +30,18 @@ class CanvasView: NSView {
     NSBezierPath(rect: bounds).fill()
     
     for concept in concepts {
-      let textField = NSTextField(frame: concept.rect)
-      textField.stringValue = concept.stringValue
-      textField.editable = true
-      addSubview(textField)
+      if !concept.added {
+        concept.added = true
+        let textField = NSTextField(frame: concept.rect)
+        textField.placeholderString = concept.stringValue
+        textField.enabled = true
+        textField.editable = true
+        addSubview(textField)
+        textField.becomeFirstResponder()
+      }
     }
   }
- 
+  
   override func mouseDown(theEvent: NSEvent) {
     delegate?.singleClick(theEvent)
   }

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -44,4 +44,9 @@ class CanvasView: NSView {
     delegate?.singleClick(theEvent)
   }
   
+
+extension NSView {
+  func sprint(message: String) {
+    Swift.print(message)
+  }
 }

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -31,13 +31,11 @@ class CanvasView: NSView {
     
     for concept in concepts {
       if !concept.added {
+        Swift.print("add concept view")
+        let conceptView = ConceptView(frame: concept.rect)
+        conceptView.concept = concept
         concept.added = true
-        let textField = NSTextField(frame: concept.rect)
-        textField.placeholderString = concept.stringValue
-        textField.enabled = true
-        textField.editable = true
-        addSubview(textField)
-        textField.becomeFirstResponder()
+        addSubview(conceptView)
       }
     }
   }
@@ -45,4 +43,5 @@ class CanvasView: NSView {
   override func mouseDown(theEvent: NSEvent) {
     delegate?.singleClick(theEvent)
   }
+  
 }

--- a/LinkedIdeas/Concept.swift
+++ b/LinkedIdeas/Concept.swift
@@ -1,0 +1,35 @@
+//
+//  Concept.swift
+//  LinkedIdeas
+//
+//  Created by Felipe Espinoza Castillo on 08/11/15.
+//  Copyright © 2015 Felipe Espinoza Dev. All rights reserved.
+//
+
+import Foundation
+
+class Concept {
+  var stringValue: String = "Insert Concpet"
+  var point: NSPoint
+  var added: Bool = false
+  var editing: Bool = false
+  var identifier = random()
+  var rect: NSRect {
+    let offset: CGFloat = 20.0
+    let size = stringValue.sizeWithAttributes(nil)
+    let x = self.point.x - size.width / 2.0 - offset
+    let y = self.point.y - size.height / 2.0 - offset
+    let point = NSPoint(x: x, y: y)
+    let bigSize = NSSize(width: size.width + offset, height: size.height + offset)
+    return NSRect(origin: point, size: bigSize)
+  }
+  
+  init(point: NSPoint) {
+    self.point = point
+  }
+  
+  func draw() {
+    stringValue.drawAtPoint(rect.origin, withAttributes: nil)
+  }
+  
+}

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -43,8 +43,8 @@ class ConceptView: NSControl, NSTextFieldDelegate {
     
     if renderedConcept {
       if editMode {
-//        textField?.hidden = false
-//        textField?.becomeFirstResponder()
+        textField?.hidden = false
+        textField?.editable = true
       } else {
         renderConcept()
       }
@@ -65,7 +65,10 @@ class ConceptView: NSControl, NSTextFieldDelegate {
   }
   
   func control(control: NSControl, textShouldEndEditing fieldEditor: NSText) -> Bool {
-    sprint("end editing \(fieldEditor.string)")
+    if let concept = concept, textField = textField {
+      concept.stringValue = textField.stringValue
+    }
+    sprint("end editing \(concept?.stringValue)")
     afterEditing()
     return true
   }
@@ -100,7 +103,6 @@ class ConceptView: NSControl, NSTextFieldDelegate {
     textField?.editable = false
     textField?.bordered = false
     textField?.resignFirstResponder()
-//    textField?.removeFromSuperview()
     textField?.hidden = true
     editMode = false
     canvas?.becomeFirstResponder()
@@ -118,7 +120,7 @@ class ConceptView: NSControl, NSTextFieldDelegate {
   
   func beforeEditing() {
     textField?.editable = true
-    textField?.bordered = true
+    textField?.hidden = false
   }
   
   override func keyDown(theEvent: NSEvent) {

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -1,0 +1,34 @@
+//
+//  ConceptView.swift
+//  LinkedIdeas
+//
+//  Created by Felipe Espinoza Castillo on 07/11/15.
+//  Copyright © 2015 Felipe Espinoza Dev. All rights reserved.
+//
+
+import Cocoa
+
+class ConceptView: NSView {
+  
+  var concept: Concept? {
+    didSet {
+      needsDisplay = true
+    }
+  }
+  var renderedConcept = false
+  
+  override func drawRect(dirtyRect: NSRect) {
+    super.drawRect(dirtyRect)
+    
+    if let concept = concept where !renderedConcept {
+      Swift.print("concept view")
+      let textField = NSTextField(frame: bounds)
+      textField.placeholderString = concept.stringValue
+      textField.enabled = true
+      textField.editable = true
+      addSubview(textField)
+      textField.becomeFirstResponder()
+      renderedConcept = true
+    }
+  }
+}

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -8,20 +8,28 @@
 
 import Cocoa
 
-class ConceptView: NSView {
+class ConceptView: NSControl, NSTextFieldDelegate {
   
   var concept: Concept? {
     didSet {
       needsDisplay = true
     }
   }
+  var editMode = true {
+    didSet {
+      needsDisplay = true
+    }
+  }
   var renderedConcept = false
+  var textField: NSTextField?
+  weak var canvas: CanvasView?
   
   override func drawRect(dirtyRect: NSRect) {
     super.drawRect(dirtyRect)
+    sprint("draw rect")
     
     if let concept = concept where !renderedConcept {
-      Swift.print("concept view")
+      Swift.print("concept view \(concept.identifier)")
       let textField = NSTextField(frame: bounds)
       textField.placeholderString = concept.stringValue
       textField.enabled = true
@@ -29,6 +37,95 @@ class ConceptView: NSView {
       addSubview(textField)
       textField.becomeFirstResponder()
       renderedConcept = true
+      textField.delegate = self
+      self.textField = textField
     }
+    
+    if renderedConcept {
+      if editMode {
+//        textField?.hidden = false
+//        textField?.becomeFirstResponder()
+      } else {
+        renderConcept()
+      }
+    }
+  }
+  
+  // MARK: - NSTextFieldDelegate
+  
+  override func mouseDown(theEvent: NSEvent) {
+    sprint("conceptView: mouse down \(concept?.identifier)")
+    editMode = true
+  }
+  
+  func control(control: NSControl, textShouldBeginEditing fieldEditor: NSText) -> Bool {
+    sprint("begin editing \(fieldEditor.string) \(concept?.identifier)")
+    beforeEditing()
+    return true
+  }
+  
+  func control(control: NSControl, textShouldEndEditing fieldEditor: NSText) -> Bool {
+    sprint("end editing \(fieldEditor.string)")
+    afterEditing()
+    return true
+  }
+  
+  func control(control: NSControl, textView: NSTextView, doCommandBySelector commandSelector: Selector) -> Bool {
+    sprint("do command \(commandSelector.description)")
+    switch commandSelector {
+    case "insertNewline:":
+      insertNewline(control)
+      return true
+    case "cancelOperation:":
+      cancelOperation(control)
+      return true
+    default:
+      return false
+    }
+  }
+  
+  override func insertNewline(sender: AnyObject?) {
+    sprint("insert new line")
+    afterEditing()
+  }
+  
+  override func cancelOperation(sender: AnyObject?) {
+    sprint("custom cancel operation")
+    afterEditing()
+    canvas?.removeConcept(concept!)
+    removeFromSuperview()
+  }
+  
+  func afterEditing() {
+    textField?.editable = false
+    textField?.bordered = false
+    textField?.resignFirstResponder()
+//    textField?.removeFromSuperview()
+    textField?.hidden = true
+    editMode = false
+    canvas?.becomeFirstResponder()
+  }
+  
+  func renderConcept() {
+    if let concept = concept, textField = textField {
+      concept.stringValue = textField.stringValue
+      let attrs = [
+        NSForegroundColorAttributeName: NSColor.blackColor()
+      ]
+      concept.stringValue.drawInRect(bounds, withAttributes: attrs)
+    }
+  }
+  
+  func beforeEditing() {
+    textField?.editable = true
+    textField?.bordered = true
+  }
+  
+  override func keyDown(theEvent: NSEvent) {
+    sprint("key down \(theEvent.characters)")
+  }
+  
+  override func sprint(message: String) {
+    super.sprint("ConceptView \(concept?.identifier): \(message)")
   }
 }

--- a/LinkedIdeas/Document.swift
+++ b/LinkedIdeas/Document.swift
@@ -8,15 +8,22 @@
 
 import Cocoa
 
-struct Concept {
+class Concept {
   let stringValue = "Hello World!"
   var point: NSPoint
+  var added: Bool = false
   var rect: NSRect {
+    let offset: CGFloat = 20.0
     let size = stringValue.sizeWithAttributes(nil)
-    let x = self.point.x - size.width / 2.0
-    let y = self.point.y - size.height / 2.0
+    let x = self.point.x - size.width / 2.0 - offset
+    let y = self.point.y - size.height / 2.0 - offset
     let point = NSPoint(x: x, y: y)
-    return NSRect(origin: point, size: size)
+    let bigSize = NSSize(width: size.width + offset, height: size.height + offset)
+    return NSRect(origin: point, size: bigSize)
+  }
+  
+  init(point: NSPoint) {
+    self.point = point
   }
   
   func draw() {

--- a/LinkedIdeas/Document.swift
+++ b/LinkedIdeas/Document.swift
@@ -8,29 +8,6 @@
 
 import Cocoa
 
-class Concept {
-  let stringValue = "Hello World!"
-  var point: NSPoint
-  var added: Bool = false
-  var rect: NSRect {
-    let offset: CGFloat = 20.0
-    let size = stringValue.sizeWithAttributes(nil)
-    let x = self.point.x - size.width / 2.0 - offset
-    let y = self.point.y - size.height / 2.0 - offset
-    let point = NSPoint(x: x, y: y)
-    let bigSize = NSSize(width: size.width + offset, height: size.height + offset)
-    return NSRect(origin: point, size: bigSize)
-  }
-  
-  init(point: NSPoint) {
-    self.point = point
-  }
-  
-  func draw() {
-    stringValue.drawAtPoint(rect.origin, withAttributes: nil)
-  }
-}
-
 class Document: NSDocument, CanvasViewDelegate {
   
   @IBOutlet weak var canvas: CanvasView!

--- a/README.md
+++ b/README.md
@@ -32,5 +32,7 @@ On the other hand, the connexions between ideas can have text on its own as a wa
 - [x] create text field and focus on it
 - [x] when editing a concept, 'escape key' to cancel and delete the concept
 - [x] accept enter and just render as text
-- [ ] when clicking a concept make it editable
+- [x] when clicking a concept make it editable
+
+#### Optional
 - [ ] when pressing 'enter' and the concept is blank, remove the concept

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ On the other hand, the connexions between ideas can have text on its own as a wa
 - [x] accept click
 - [x] draw a string in a certain position on click
 - [x] create text field and focus on it
-- [ ] accept 'escape' key to cancel, deleting the concept
-- [ ] accept enter and just render as text
-- [ ] accept entering multiple concepts
+- [x] when editing a concept, 'escape key' to cancel and delete the concept
+- [x] accept enter and just render as text
+- [ ] when clicking a concept make it editable
+- [ ] when pressing 'enter' and the concept is blank, remove the concept

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ On the other hand, the connexions between ideas can have text on its own as a wa
 - [x] draw canvas
 - [x] accept click
 - [x] draw a string in a certain position on click
-- [ ] create text field and focus on it
-- [ ] accept 'escape' key to cancel
+- [x] create text field and focus on it
+- [ ] accept 'escape' key to cancel, deleting the concept
 - [ ] accept enter and just render as text
 - [ ] accept entering multiple concepts


### PR DESCRIPTION
- Make concept editable when clicking on it
- Handle key/mouse event on ConceptView
  - when editing a concept, 'escape key' to cancel and delete the concept
  - accept enter and just render as text
- Make Concept a class in it's own file
- Add NSView.sprintf function in extension
- Add custom view, concept view
- On click, create text field and focus on it
- turn Concept struct into class because i need the reference to change
  the properties of the class