### PR TITLE
Feature: Adding links between concepts

### DIFF
--- a/LinkedIdeas.xcodeproj/project.pbxproj
+++ b/LinkedIdeas.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		9B2F1DCE1BE7D3990090CC18 /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2F1DCD1BE7D3990090CC18 /* CanvasView.swift */; };
 		9B956CE51C1B11C200CF20DA /* NSPoint+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B956CE41C1B11C200CF20DA /* NSPoint+Utilities.swift */; };
 		9BABB2B21C07B7F7001EC9E0 /* Link.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BABB2B11C07B7F7001EC9E0 /* Link.swift */; };
+		9BB8FC831CA6B7D7008CD6A2 /* LinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB8FC821CA6B7D7008CD6A2 /* LinkTests.swift */; };
+		9BB8FC851CA6B7F8008CD6A2 /* LinkViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB8FC841CA6B7F8008CD6A2 /* LinkViewTests.swift */; };
+		9BB8FC871CA6B828008CD6A2 /* LinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB8FC861CA6B828008CD6A2 /* LinkView.swift */; };
+		9BB8FC891CA6B889008CD6A2 /* Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB8FC881CA6B889008CD6A2 /* Element.swift */; };
 		9BD2BF351C7F8B1200E8A303 /* LineRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD2BF341C7F8B1200E8A303 /* LineRange.swift */; };
 		9BD2BF371C7F8B2300E8A303 /* Interceptable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD2BF361C7F8B2300E8A303 /* Interceptable.swift */; };
 		9BD2BF391C7F8B4100E8A303 /* PointInterceptable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD2BF381C7F8B4100E8A303 /* PointInterceptable.swift */; };
@@ -55,6 +59,10 @@
 		9B2F1DCD1BE7D3990090CC18 /* CanvasView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
 		9B956CE41C1B11C200CF20DA /* NSPoint+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSPoint+Utilities.swift"; sourceTree = "<group>"; };
 		9BABB2B11C07B7F7001EC9E0 /* Link.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Link.swift; sourceTree = "<group>"; };
+		9BB8FC821CA6B7D7008CD6A2 /* LinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkTests.swift; sourceTree = "<group>"; };
+		9BB8FC841CA6B7F8008CD6A2 /* LinkViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkViewTests.swift; sourceTree = "<group>"; };
+		9BB8FC861CA6B828008CD6A2 /* LinkView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkView.swift; sourceTree = "<group>"; };
+		9BB8FC881CA6B889008CD6A2 /* Element.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Element.swift; sourceTree = "<group>"; };
 		9BD2BF341C7F8B1200E8A303 /* LineRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineRange.swift; sourceTree = "<group>"; };
 		9BD2BF361C7F8B2300E8A303 /* Interceptable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Interceptable.swift; sourceTree = "<group>"; };
 		9BD2BF381C7F8B4100E8A303 /* PointInterceptable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PointInterceptable.swift; sourceTree = "<group>"; };
@@ -123,12 +131,30 @@
 		9B2F1DB31BE7CFE80090CC18 /* LinkedIdeasTests */ = {
 			isa = PBXGroup;
 			children = (
-				9BF058F71C921F7D00274A62 /* CanvasViewTests.swift */,
-				9BF058F81C921F7D00274A62 /* ConceptViewTests.swift */,
-				9BF058FB1C9220F200274A62 /* ConceptTests.swift */,
+				9BB8FC811CA6B7C0008CD6A2 /* Views */,
+				9BB8FC801CA6B7B0008CD6A2 /* Models */,
 				9B2F1DB61BE7CFE80090CC18 /* Info.plist */,
 			);
 			path = LinkedIdeasTests;
+			sourceTree = "<group>";
+		};
+		9BB8FC801CA6B7B0008CD6A2 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				9BF058FB1C9220F200274A62 /* ConceptTests.swift */,
+				9BB8FC821CA6B7D7008CD6A2 /* LinkTests.swift */,
+			);
+			name = Models;
+			sourceTree = "<group>";
+		};
+		9BB8FC811CA6B7C0008CD6A2 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				9BF058F71C921F7D00274A62 /* CanvasViewTests.swift */,
+				9BF058F81C921F7D00274A62 /* ConceptViewTests.swift */,
+				9BB8FC841CA6B7F8008CD6A2 /* LinkViewTests.swift */,
+			);
+			name = Views;
 			sourceTree = "<group>";
 		};
 		9BCA09E31C9217A900637F6D /* Models */ = {
@@ -136,6 +162,7 @@
 			children = (
 				9BDDE7381BEF9157000AAD44 /* Concept.swift */,
 				9BABB2B11C07B7F7001EC9E0 /* Link.swift */,
+				9BB8FC881CA6B889008CD6A2 /* Element.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -145,6 +172,7 @@
 			children = (
 				9B2F1DCD1BE7D3990090CC18 /* CanvasView.swift */,
 				9BD2C14D1BEE6F9F00CD3C2F /* ConceptView.swift */,
+				9BB8FC861CA6B828008CD6A2 /* LinkView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -268,6 +296,7 @@
 			files = (
 				9BABB2B21C07B7F7001EC9E0 /* Link.swift in Sources */,
 				9B2F1DA21BE7CFE70090CC18 /* Document.swift in Sources */,
+				9BB8FC871CA6B828008CD6A2 /* LinkView.swift in Sources */,
 				9B956CE51C1B11C200CF20DA /* NSPoint+Utilities.swift in Sources */,
 				9B06AD151C11AF03000BC75C /* NSView+Debugging.swift in Sources */,
 				9BD2BF3D1C7F8B6A00E8A303 /* FiniteLine.swift in Sources */,
@@ -276,6 +305,7 @@
 				9BD2BF421C7F8C2000E8A303 /* Arrow.swift in Sources */,
 				9BD2BF371C7F8B2300E8A303 /* Interceptable.swift in Sources */,
 				9BD2BF391C7F8B4100E8A303 /* PointInterceptable.swift in Sources */,
+				9BB8FC891CA6B889008CD6A2 /* Element.swift in Sources */,
 				9B2F1DCE1BE7D3990090CC18 /* CanvasView.swift in Sources */,
 				9BD2C14E1BEE6F9F00CD3C2F /* ConceptView.swift in Sources */,
 				9BD2BF3B1C7F8B5500E8A303 /* Line.swift in Sources */,
@@ -291,6 +321,8 @@
 				9BF058FC1C9220F200274A62 /* ConceptTests.swift in Sources */,
 				9BF058F91C921F7D00274A62 /* CanvasViewTests.swift in Sources */,
 				9BF058FA1C921F7D00274A62 /* ConceptViewTests.swift in Sources */,
+				9BB8FC831CA6B7D7008CD6A2 /* LinkTests.swift in Sources */,
+				9BB8FC851CA6B7F8008CD6A2 /* LinkViewTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -31,7 +31,7 @@ protocol CanvasLinkActions {
   func showConstructionArrow()
   func removeConstructionArrow()
 
-  func selectTargetConceptView(point: NSPoint) -> ConceptView?
+  func selectTargetConceptView(point: NSPoint, fromConcept originConcept: Concept) -> ConceptView?
   func createLinkBetweenConceptsViews(originConceptView: ConceptView, targetConceptView: ConceptView)
 }
 
@@ -175,7 +175,7 @@ class CanvasView: NSView, Canvas {
   }
   
   func releaseMouseFromConceptView(conceptView: ConceptView, point: NSPoint) {
-    if let targetedConceptView = selectTargetConceptView(point) {
+    if let targetedConceptView = selectTargetConceptView(point, fromConcept: conceptView.concept) {
       createLinkBetweenConceptsViews(conceptView, targetConceptView: targetedConceptView)
     }
     
@@ -203,9 +203,9 @@ class CanvasView: NSView, Canvas {
     arrowTargetPoint = nil
   }
   
-  func selectTargetConceptView(point: NSPoint) -> ConceptView? {
+  func selectTargetConceptView(point: NSPoint, fromConcept originConcept: Concept) -> ConceptView? {
     for (_, conceptView) in conceptViews {
-      if (mode == .Links && CGRectContainsPoint(conceptView.frame, point)) {
+      if (mode == .Links && conceptView.concept != originConcept && CGRectContainsPoint(conceptView.frame, point)) {
         return conceptView
       }
     }

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -25,6 +25,7 @@ protocol CanvasConceptsActions {
   func clickOnConceptView(conceptView: ConceptView, point: NSPoint)
   func dragFromConceptView(conceptView: ConceptView, point: NSPoint)
   func releaseMouseFromConceptView(conceptView: ConceptView, point: NSPoint)
+  func updateLinkViewsFor(concept: Concept)
 }
 
 protocol CanvasLinkActions {
@@ -50,6 +51,7 @@ protocol BasicCanvas {
   
   func pointInCanvasCoordinates(point: NSPoint) -> NSPoint
   func conceptViewFor(concept: Concept) -> ConceptView
+  func linkViewFor(link: Link) -> LinkView
 }
 
 // Protocol compositions
@@ -117,6 +119,10 @@ class CanvasView: NSView, Canvas {
   func conceptViewFor(concept: Concept) -> ConceptView {
     return conceptViews[concept.identifier]!
   }
+  
+  func linkViewFor(link: Link) -> LinkView {
+    return linkViews[link.identifier]!
+  }
 
   // MARK: - CanvasConceptsActions
   
@@ -177,6 +183,7 @@ class CanvasView: NSView, Canvas {
     sprint("drag from conceptView \(conceptView.concept.identifier) to \(point)")
     arrowOriginPoint = conceptView.concept.point
     arrowTargetPoint = point
+    updateLinkViewsFor(conceptView.concept)
     needsDisplay = true
   }
   
@@ -194,6 +201,13 @@ class CanvasView: NSView, Canvas {
     newConcept = nil
   }
   
+  func updateLinkViewsFor(concept: Concept) {
+    let conceptLinks = links.filter {
+      return $0.origin.identifier == concept.identifier || $0.target.identifier == concept.identifier
+    }
+    for link in conceptLinks { linkViewFor(link).needsDisplay = true }
+  }
+  
   // MARK: - CanvasLinkActions
   
   func drawLinkViews() {
@@ -204,6 +218,7 @@ class CanvasView: NSView, Canvas {
     if let linkView = linkViews[link.identifier] {
       linkView.needsDisplay = true
     } else {
+      sprint("draw new link view for \(link)")
       let linkView = LinkView(link: link, canvas: self)
       addSubview(linkView)
       linkViews[link.identifier] = linkView

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -46,6 +46,7 @@ protocol BasicCanvas {
   func saveConcept(concept: ConceptView)
   
   func pointInCanvasCoordinates(point: NSPoint) -> NSPoint
+  func conceptViewFor(concept: Concept) -> ConceptView
 }
 
 // Protocol compositions
@@ -108,8 +109,13 @@ class CanvasView: NSView, Canvas {
   func pointInCanvasCoordinates(point: NSPoint) -> NSPoint {
     return convertPoint(point, fromView: nil)
   }
+  
+  func conceptViewFor(concept: Concept) -> ConceptView {
+    return conceptViews[concept.identifier]!
+  }
 
   // MARK: - CanvasConceptsActions
+  
   func drawConceptViews() {
     for concept in concepts { drawConceptView(concept) }
   }
@@ -153,7 +159,7 @@ class CanvasView: NSView, Canvas {
       if (concept.identifier != selectedConcept.identifier) {
         concept.isSelected = false
         concept.isEditable = false
-        conceptViews[concept.identifier]!.needsDisplay = true
+        conceptViewFor(concept).needsDisplay = true
       }
     }
     cleanNewConcept()

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -56,6 +56,7 @@ class CanvasView: NSView, Canvas {
   var newConceptView: ConceptView? = nil
   var concepts: [Concept] = [Concept]()
   var conceptViews: [String: ConceptView] = [String: ConceptView]()
+  var mode: Mode = Mode.Concepts
 
   // MARK - NSView
   override func drawRect(dirtyRect: NSRect) {

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -205,7 +205,7 @@ class CanvasView: NSView, Canvas {
     let conceptLinks = links.filter {
       return $0.origin.identifier == concept.identifier || $0.target.identifier == concept.identifier
     }
-    for link in conceptLinks { linkViewFor(link).needsDisplay = true }
+    for link in conceptLinks { linkViewFor(link).frame = link.minimalRect }
   }
   
   // MARK: - CanvasLinkActions

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -23,6 +23,16 @@ protocol CanvasConceptsActions {
   func drawConceptViews()
   func drawConceptView(concept: Concept)
   func clickOnConceptView(conceptView: ConceptView, point: NSPoint)
+  func dragFromConceptView(conceptView: ConceptView, point: NSPoint)
+  func releaseMouseFromConceptView(conceptView: ConceptView, point: NSPoint)
+}
+
+protocol CanvasLinkActions {
+  func showConstructionArrow()
+  func removeConstructionArrow()
+
+  func selectTargetConceptView(point: NSPoint) -> ConceptView?
+  func createLinkBetweenConceptsViews(originConceptView: ConceptView, targetConceptView: ConceptView)
 }
 
 protocol BasicCanvas {
@@ -38,7 +48,7 @@ protocol BasicCanvas {
 
 // Protocol compositions
 
-typealias Canvas = protocol<BasicCanvas, ClickableView, CanvasConceptsActions>
+typealias Canvas = protocol<BasicCanvas, ClickableView, CanvasConceptsActions, CanvasLinkActions>
 
 // Protocol conditional extension
 extension ClickableView where Self: CanvasConceptsActions {
@@ -57,12 +67,16 @@ class CanvasView: NSView, Canvas {
   var concepts: [Concept] = [Concept]()
   var conceptViews: [String: ConceptView] = [String: ConceptView]()
   var mode: Mode = Mode.Concepts
+  var links: [Link] = [Link]()
+  var linkViews: [String: LinkView] = [String: LinkView]()
 
   // MARK - NSView
   override func drawRect(dirtyRect: NSRect) {
     NSColor.whiteColor().set()
     NSRectFill(bounds)
     drawConceptViews()
+    
+    if (mode == .Links) { showConstructionArrow() }
   }
 
   // MARK - MouseEvents
@@ -135,10 +149,62 @@ class CanvasView: NSView, Canvas {
     }
     cleanNewConcept()
   }
+  
+  var arrowOriginPoint: NSPoint?
+  var arrowTargetPoint: NSPoint?
+  
+  func dragFromConceptView(conceptView: ConceptView, point: NSPoint) {
+    arrowOriginPoint = conceptView.concept.point
+    arrowTargetPoint = point
+    needsDisplay = true
+  }
+  
+  func releaseMouseFromConceptView(conceptView: ConceptView, point: NSPoint) {
+    if let targetedConceptView = selectTargetConceptView(point) {
+      createLinkBetweenConceptsViews(conceptView, targetConceptView: targetedConceptView)
+    }
+    
+    removeConstructionArrow()
+  }
 
   func cleanNewConcept() {
     newConceptView?.removeFromSuperview()
     newConceptView = nil
     newConcept = nil
+  }
+  
+  // MARK: - CanvasLinkActions
+  func showConstructionArrow() {
+    if let arrowOriginPoint = arrowOriginPoint, arrowTargetPoint = arrowTargetPoint {
+      NSColor.blueColor().set()
+      let arrow = Arrow(p1: arrowOriginPoint, p2: arrowTargetPoint)
+      arrow.bezierPath().fill()
+    }
+  }
+  
+  func removeConstructionArrow() {
+    arrowOriginPoint = nil
+    arrowTargetPoint = nil
+  }
+  
+  func selectTargetConceptView(point: NSPoint) -> ConceptView? {
+    for (_, conceptView) in conceptViews {
+      if (mode == .Links && CGRectContainsPoint(conceptView.frame, point)) {
+        return conceptView
+      }
+    }
+
+    return nil
+  }
+  
+  func createLinkBetweenConceptsViews(originConceptView: ConceptView, targetConceptView: ConceptView) {
+    Swift.print(">>>>> create link between concepts")
+    let link = Link(origin: originConceptView.concept, target: targetConceptView.concept)
+    let linkView = LinkView(link: link, canvas: self)
+    
+    addSubview(linkView)
+    
+    links.append(link)
+    linkViews[link.identifier] = linkView
   }
 }

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -44,6 +44,8 @@ protocol BasicCanvas {
 
   func addConceptView(concept: Concept)
   func saveConcept(concept: ConceptView)
+  
+  func pointInCanvasCoordinates(point: NSPoint) -> NSPoint
 }
 
 // Protocol compositions
@@ -83,7 +85,7 @@ class CanvasView: NSView, Canvas {
   // MARK: - MouseEvents
   
   override func mouseDown(theEvent: NSEvent) {
-    let clickedPoint = convertPoint(theEvent.locationInWindow, fromView: nil)
+    let clickedPoint = pointInCanvasCoordinates(theEvent.locationInWindow)
     click(clickedPoint)
   }
 
@@ -101,6 +103,10 @@ class CanvasView: NSView, Canvas {
 
     concepts.append(_newConcept)
     conceptViews[_newConcept.identifier] = _newConceptView
+  }
+  
+  func pointInCanvasCoordinates(point: NSPoint) -> NSPoint {
+    return convertPoint(point, fromView: nil)
   }
 
   // MARK: - CanvasConceptsActions

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -70,7 +70,8 @@ class CanvasView: NSView, Canvas {
   var links: [Link] = [Link]()
   var linkViews: [String: LinkView] = [String: LinkView]()
 
-  // MARK - NSView
+  // MARK: - NSView
+  
   override func drawRect(dirtyRect: NSRect) {
     NSColor.whiteColor().set()
     NSRectFill(bounds)
@@ -79,13 +80,15 @@ class CanvasView: NSView, Canvas {
     if (mode == .Links) { showConstructionArrow() }
   }
 
-  // MARK - MouseEvents
+  // MARK: - MouseEvents
+  
   override func mouseDown(theEvent: NSEvent) {
     let clickedPoint = convertPoint(theEvent.locationInWindow, fromView: nil)
     click(clickedPoint)
   }
 
-  // MARK - BasicCanvas
+  // MARK: - BasicCanvas
+  
   func addConceptView(concept: Concept) {
   }
 
@@ -100,7 +103,7 @@ class CanvasView: NSView, Canvas {
     conceptViews[_newConcept.identifier] = _newConceptView
   }
 
-  // MARK - CanvasConceptsActions
+  // MARK: - CanvasConceptsActions
   func drawConceptViews() {
     for concept in concepts { drawConceptView(concept) }
   }
@@ -174,6 +177,7 @@ class CanvasView: NSView, Canvas {
   }
   
   // MARK: - CanvasLinkActions
+  
   func showConstructionArrow() {
     if let arrowOriginPoint = arrowOriginPoint, arrowTargetPoint = arrowTargetPoint {
       NSColor.blueColor().set()
@@ -198,7 +202,6 @@ class CanvasView: NSView, Canvas {
   }
   
   func createLinkBetweenConceptsViews(originConceptView: ConceptView, targetConceptView: ConceptView) {
-    Swift.print(">>>>> create link between concepts")
     let link = Link(origin: originConceptView.concept, target: targetConceptView.concept)
     let linkView = LinkView(link: link, canvas: self)
     

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -158,6 +158,7 @@ class CanvasView: NSView, Canvas {
   }
 
   func clickOnConceptView(conceptView: ConceptView, point: NSPoint) {
+    sprint("click on conceptView \(conceptView.concept.identifier) to \(point)")
     let selectedConcept = conceptView.concept
     for concept in concepts {
       if (concept.identifier != selectedConcept.identifier) {
@@ -173,6 +174,7 @@ class CanvasView: NSView, Canvas {
   var arrowTargetPoint: NSPoint?
   
   func dragFromConceptView(conceptView: ConceptView, point: NSPoint) {
+    sprint("drag from conceptView \(conceptView.concept.identifier) to \(point)")
     arrowOriginPoint = conceptView.concept.point
     arrowTargetPoint = point
     needsDisplay = true
@@ -235,8 +237,13 @@ class CanvasView: NSView, Canvas {
     let link = Link(origin: originConceptView.concept, target: targetConceptView.concept)
     links.append(link)
     
+    sprint("create link \(link)")
     
     drawLinkView(link)
   }
+  
+  // MARK: - Debugging
+  func sprint(message: String) {
+    Swift.print("[CanvasView]: \(message)")
   }
 }

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -30,6 +30,9 @@ protocol CanvasConceptsActions {
 protocol CanvasLinkActions {
   func showConstructionArrow()
   func removeConstructionArrow()
+  
+  func drawLinkViews()
+  func drawLinkView(link: Link)
 
   func selectTargetConceptView(point: NSPoint, fromConcept originConcept: Concept) -> ConceptView?
   func createLinkBetweenConceptsViews(originConceptView: ConceptView, targetConceptView: ConceptView)
@@ -79,6 +82,7 @@ class CanvasView: NSView, Canvas {
     NSColor.whiteColor().set()
     NSRectFill(bounds)
     drawConceptViews()
+    drawLinkViews()
     
     if (mode == .Links) { showConstructionArrow() }
   }
@@ -190,6 +194,20 @@ class CanvasView: NSView, Canvas {
   
   // MARK: - CanvasLinkActions
   
+  func drawLinkViews() {
+    for link in links { drawLinkView(link) }
+  }
+  
+  func drawLinkView(link: Link) {
+    if let linkView = linkViews[link.identifier] {
+      linkView.needsDisplay = true
+    } else {
+      let linkView = LinkView(link: link, canvas: self)
+      addSubview(linkView)
+      linkViews[link.identifier] = linkView
+    }
+  }
+  
   func showConstructionArrow() {
     if let arrowOriginPoint = arrowOriginPoint, arrowTargetPoint = arrowTargetPoint {
       NSColor.blueColor().set()
@@ -215,11 +233,10 @@ class CanvasView: NSView, Canvas {
   
   func createLinkBetweenConceptsViews(originConceptView: ConceptView, targetConceptView: ConceptView) {
     let link = Link(origin: originConceptView.concept, target: targetConceptView.concept)
-    let linkView = LinkView(link: link, canvas: self)
-    
-    addSubview(linkView)
-    
     links.append(link)
-    linkViews[link.identifier] = linkView
+    
+    
+    drawLinkView(link)
+  }
   }
 }

--- a/LinkedIdeas/Concept.swift
+++ b/LinkedIdeas/Concept.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 class Concept: NSObject, NSCoding, Element, VisualElement, StringElement {
+  // NOTE: the point value is relative to the canvas coordinate system
   var point: NSPoint
   // element
   var identifier: String

--- a/LinkedIdeas/Concept.swift
+++ b/LinkedIdeas/Concept.swift
@@ -35,7 +35,7 @@ class Concept: NSObject, NSCoding, Element, VisualElement, StringElement {
 
   init(stringValue: String, point: NSPoint) {
     self.point = point
-    self.identifier = "\(random())-concept"
+    self.identifier = "\(random()*10000)-concept"
     self.stringValue = stringValue
   }
 

--- a/LinkedIdeas/Concept.swift
+++ b/LinkedIdeas/Concept.swift
@@ -8,18 +8,7 @@
 
 import Foundation
 
-protocol Element {
-  var identifier: String { get }
-  var stringValue: String { get  set }
-  var minimalRect: NSRect { get }
-}
-
-protocol VisualElement {
-  var isEditable: Bool { get set }
-  var isSelected: Bool { get set }
-}
-
-class Concept: NSObject, NSCoding, Element, VisualElement {
+class Concept: NSObject, NSCoding, Element, VisualElement, StringElement {
   var point: NSPoint
   // element
   var identifier: String

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -101,10 +101,9 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
   override func drawRect(dirtyRect: NSRect) {
     if concept.isSelected {
       NSColor.greenColor().set()
-    } else {
-      NSColor.lightGrayColor().set()
+      NSRectFill(bounds)
     }
-    NSRectFill(bounds)
+    
     toggleTextFieldEditMode()
     if !concept.isEditable { drawString() }
   }

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -113,11 +113,14 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
   }
 
   override func mouseDragged(theEvent: NSEvent) {
+    Swift.print("mouse dragged: \(theEvent.locationInWindow)")
     dragTo(theEvent.locationInWindow)
   }
 
   override func mouseUp(theEvent: NSEvent) {
+    Swift.print("mouse up: \(theEvent.locationInWindow)")
     dragTo(theEvent.locationInWindow)
+    canvas.releaseMouseFromConceptView(self, point: theEvent.locationInWindow)
   }
 
   // MARK: - NSTextFieldDelegate

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -128,7 +128,7 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
   override func mouseUp(theEvent: NSEvent) {
     let point = pointInCanvasCoordinates(theEvent.locationInWindow)
     dragTo(point)
-    canvas.releaseMouseFromConceptView(self, point: theEvent.locationInWindow)
+    canvas.releaseMouseFromConceptView(self, point: point)
   }
 
   // MARK: - NSTextFieldDelegate

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -179,7 +179,10 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
 
   // MARK - Dragable element
   func dragTo(point: NSPoint) {
-    concept.point = point
-    frame = concept.minimalRect
+    if (canvas.mode == .Concepts) {
+      concept.point = point
+      frame = concept.minimalRect
+    }
+    canvas.dragFromConceptView(self, point: point)
   }
 }

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -188,7 +188,7 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
     concept.stringValue.drawInRect(stringRect, withAttributes: nil)
   }
 
-  // MARK - Dragable element
+  // MARK: - Dragable element
   func dragTo(point: NSPoint) {
     if (canvas.mode == .Concepts) {
       concept.point = point

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -112,6 +112,7 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
   // MARK: - Mouse events
 
   override func mouseDown(theEvent: NSEvent) {
+    sprint("mouse down")
     let point = pointInCanvasCoordinates(theEvent.locationInWindow)
     if (theEvent.clickCount == 2) {
       doubleClick(point)
@@ -121,11 +122,13 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
   }
 
   override func mouseDragged(theEvent: NSEvent) {
+    sprint("mouse drag")
     let point = pointInCanvasCoordinates(theEvent.locationInWindow)
     dragTo(point)
   }
 
   override func mouseUp(theEvent: NSEvent) {
+    sprint("mouse up")
     let point = pointInCanvasCoordinates(theEvent.locationInWindow)
     dragTo(point)
     canvas.releaseMouseFromConceptView(self, point: point)
@@ -134,6 +137,7 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
   // MARK: - NSTextFieldDelegate
 
   func control(control: NSControl, textView: NSTextView, doCommandBySelector commandSelector: Selector) -> Bool {
+    sprint("use selector \(commandSelector)")
     switch commandSelector {
     case #selector(NSResponder.insertNewline(_:)):
       pressEnterKey()
@@ -190,10 +194,16 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
 
   // MARK: - Dragable element
   func dragTo(point: NSPoint) {
+    sprint("drag")
     if (canvas.mode == .Concepts) {
       concept.point = point
       frame = concept.minimalRect
     }
     canvas.dragFromConceptView(self, point: point)
+  }
+  
+  // MARK: - Debugging
+  func sprint(message: String) {
+    Swift.print("[ConceptView][\(concept.identifier)][\(concept.stringValue)]: \(message)")
   }
 }

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -48,6 +48,14 @@ extension StringEditableView {
 
 protocol CanvasElement {
   var canvas: CanvasView { get }
+  
+  func pointInCanvasCoordinates(point: NSPoint) -> NSPoint
+}
+
+extension CanvasElement {
+  func pointInCanvasCoordinates(point: NSPoint) -> NSPoint {
+    return canvas.pointInCanvasCoordinates(point)
+  }
 }
 
 protocol ConceptViewProtocol {
@@ -104,7 +112,7 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
   // MARK: - Mouse events
 
   override func mouseDown(theEvent: NSEvent) {
-    let point = convertPoint(theEvent.locationInWindow, fromView: nil)
+    let point = pointInCanvasCoordinates(theEvent.locationInWindow)
     if (theEvent.clickCount == 2) {
       doubleClick(point)
     } else {
@@ -113,11 +121,13 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
   }
 
   override func mouseDragged(theEvent: NSEvent) {
-    dragTo(theEvent.locationInWindow)
+    let point = pointInCanvasCoordinates(theEvent.locationInWindow)
+    dragTo(point)
   }
 
   override func mouseUp(theEvent: NSEvent) {
-    dragTo(theEvent.locationInWindow)
+    let point = pointInCanvasCoordinates(theEvent.locationInWindow)
+    dragTo(point)
     canvas.releaseMouseFromConceptView(self, point: theEvent.locationInWindow)
   }
 

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -113,12 +113,10 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
   }
 
   override func mouseDragged(theEvent: NSEvent) {
-    Swift.print("mouse dragged: \(theEvent.locationInWindow)")
     dragTo(theEvent.locationInWindow)
   }
 
   override func mouseUp(theEvent: NSEvent) {
-    Swift.print("mouse up: \(theEvent.locationInWindow)")
     dragTo(theEvent.locationInWindow)
     canvas.releaseMouseFromConceptView(self, point: theEvent.locationInWindow)
   }

--- a/LinkedIdeas/Document.swift
+++ b/LinkedIdeas/Document.swift
@@ -53,7 +53,7 @@ class Document: NSDocument {
     super.windowControllerDidLoadNib(aController)
     // Add any code here that needs to be executed once the windowController has loaded the document's window.
     if let readConcepts = documentData.readConcepts { canvas.concepts = readConcepts }
-    //    if let readLinks = documentData.readLinks { canvas.links = readLinks }
+    if let readLinks = documentData.readLinks { canvas.links = readLinks }
     canvas.mode = editionMode
     ultraWindow.acceptsMouseMovedEvents = true
   }
@@ -72,7 +72,7 @@ class Document: NSDocument {
     // Insert code here to write your document to data of the specified type. If outError != nil, ensure that you create and set an appropriate error when returning nil.
     // You can also choose to override fileWrapperOfType:error:, writeToURL:ofType:error:, or writeToURL:ofType:forSaveOperation:originalContentsURL:error: instead.
     documentData.writeConcepts = canvas.concepts
-    //    documentData.writeLinks = canvas.links
+    documentData.writeLinks = canvas.links
     return NSKeyedArchiver.archivedDataWithRootObject(documentData)
   }
 

--- a/LinkedIdeas/Document.swift
+++ b/LinkedIdeas/Document.swift
@@ -54,7 +54,7 @@ class Document: NSDocument {
     // Add any code here that needs to be executed once the windowController has loaded the document's window.
     if let readConcepts = documentData.readConcepts { canvas.concepts = readConcepts }
     //    if let readLinks = documentData.readLinks { canvas.links = readLinks }
-    //    canvas.mode = editionMode
+    canvas.mode = editionMode
     ultraWindow.acceptsMouseMovedEvents = true
   }
 
@@ -89,6 +89,6 @@ class Document: NSDocument {
     } else {
       editionMode = .Links
     }
-    //    canvas.mode = editionMode
+    canvas.mode = editionMode
   }
 }

--- a/LinkedIdeas/Element.swift
+++ b/LinkedIdeas/Element.swift
@@ -1,0 +1,23 @@
+//
+//  Element.swift
+//  LinkedIdeas
+//
+//  Created by Felipe Espinoza Castillo on 26/03/16.
+//  Copyright © 2016 Felipe Espinoza Dev. All rights reserved.
+//
+
+import Foundation
+
+protocol Element {
+  var identifier: String { get }
+  var minimalRect: NSRect { get }
+}
+
+protocol StringElement {
+  var stringValue: String { get  set }
+}
+
+protocol VisualElement {
+  var isEditable: Bool { get set }
+  var isSelected: Bool { get set }
+}

--- a/LinkedIdeas/Line.swift
+++ b/LinkedIdeas/Line.swift
@@ -48,7 +48,6 @@ struct Line: PointInterceptable {
   // it does not considate the same lines: the answer is all the points
   func intersectionPointWith(line: Line) -> NSPoint? {
     if (isParallelTo(line)) {
-      Swift.print("parallel case")
       return nil
     }
     

--- a/LinkedIdeas/Link.swift
+++ b/LinkedIdeas/Link.swift
@@ -28,7 +28,7 @@ class Link: NSObject, NSCoding, Element {
   init(origin: Concept, target: Concept) {
     self.origin = origin
     self.target = target
-    self.identifier = "\(random())-link"
+    self.identifier = "\(random()*10000)-link"
   }
   
   let identifierKey = "identifierKey"

--- a/LinkedIdeas/Link.swift
+++ b/LinkedIdeas/Link.swift
@@ -8,40 +8,41 @@
 
 import Foundation
 
-class Link: NSObject, NSCoding {
+class Link: NSObject, NSCoding, Element {
+  // own attributes
   var origin: Concept
   var target: Concept
-  var stringValue: String = ""
   var originPoint: NSPoint { return origin.point }
   var targetPoint: NSPoint { return target.point }
-  var rect: NSRect { return NSRect(p1: originPoint, p2: targetPoint) }
-  var added: Bool
-  var editing: Bool
+  
   override var description: String {
-    return "'\(origin.stringValue)' \(stringValue) '\(target.stringValue)'"
+    return "'\(origin.stringValue)' '\(target.stringValue)'"
+  }
+  
+  // Element
+  var identifier: String
+  var minimalRect: NSRect {
+    return NSRect(p1: originPoint, p2: targetPoint)
   }
   
   init(origin: Concept, target: Concept) {
     self.origin = origin
     self.target = target
-    self.added  = false
-    self.editing = false
+    self.identifier = "\(random())-link"
   }
   
-  let stringValueKey = "StringValueKey"
+  let identifierKey = "identifierKey"
   let originKey = "OriginKey"
   let targetKey = "TargetKey"
   
   required init?(coder aDecoder: NSCoder) {
-    stringValue = aDecoder.decodeObjectForKey(stringValueKey) as! String
+    identifier = aDecoder.decodeObjectForKey(identifierKey) as! String
     origin = aDecoder.decodeObjectForKey(originKey) as! Concept
     target = aDecoder.decodeObjectForKey(targetKey) as! Concept
-    added = false
-    editing = false
   }
   
   func encodeWithCoder(aCoder: NSCoder) {
-    aCoder.encodeObject(stringValue, forKey: stringValueKey)
+    aCoder.encodeObject(identifier, forKey: identifierKey)
     aCoder.encodeObject(origin, forKey: originKey)
     aCoder.encodeObject(target, forKey: targetKey)
   }

--- a/LinkedIdeas/Link.swift
+++ b/LinkedIdeas/Link.swift
@@ -15,6 +15,8 @@ class Link: NSObject, NSCoding, Element {
   var originPoint: NSPoint { return origin.point }
   var targetPoint: NSPoint { return target.point }
   
+  private let padding: CGFloat = 20
+  
   override var description: String {
     return "'\(origin.stringValue)' '\(target.stringValue)'"
   }
@@ -22,7 +24,15 @@ class Link: NSObject, NSCoding, Element {
   // Element
   var identifier: String
   var minimalRect: NSRect {
-    return NSRect(p1: originPoint, p2: targetPoint)
+    var minX = min(originPoint.x, targetPoint.x)
+    if (abs(originPoint.x - targetPoint.x) <= padding) { minX -= padding / 2 }
+    var minY = min(originPoint.y, targetPoint.y)
+    if (abs(originPoint.y - targetPoint.y) <= padding) { minY -= padding / 2 }
+    let maxX = max(originPoint.x, targetPoint.x)
+    let maxY = max(originPoint.y, targetPoint.y)
+    let width = max(maxX - minX, padding)
+    let height = max(maxY - minY, padding)
+    return NSMakeRect(minX, minY, width, height)
   }
   
   init(origin: Concept, target: Concept) {

--- a/LinkedIdeas/LinkView.swift
+++ b/LinkedIdeas/LinkView.swift
@@ -1,0 +1,50 @@
+//
+//  LinkView.swift
+//  LinkedIdeas
+//
+//  Created by Felipe Espinoza Castillo on 26/03/16.
+//  Copyright © 2016 Felipe Espinoza Dev. All rights reserved.
+//
+
+import Cocoa
+
+protocol ArrowDrawable {
+  func constructArrow() -> Arrow
+  func drawArrow()
+}
+
+class LinkView: NSView, CanvasElement, ArrowDrawable {
+  // own
+  var link: Link
+  
+  // CanvasElement
+  var canvas: CanvasView
+  
+  init(link: Link, canvas: CanvasView) {
+    self.link = link
+    self.canvas = canvas
+    super.init(frame: link.minimalRect)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func drawRect(dirtyRect: NSRect) {
+    drawArrow()
+  }
+  
+  // MARK: - ArrowDrawable
+  func constructArrow() -> Arrow {
+    let originPoint = canvas.convertPoint(link.originPoint, toView: nil)
+    let targetPoint = canvas.convertPoint(link.targetPoint, toView: nil)
+    Swift.print("draw arrow between \(originPoint) and \(targetPoint)")
+    return Arrow(p1: originPoint, p2: targetPoint)
+  }
+  
+  func drawArrow() {
+    let arrowPath = constructArrow().bezierPath()
+    NSColor.grayColor().set()
+    arrowPath.fill()
+  }
+}

--- a/LinkedIdeas/LinkView.swift
+++ b/LinkedIdeas/LinkView.swift
@@ -36,9 +36,7 @@ class LinkView: NSView, CanvasElement, ArrowDrawable {
   
   // MARK: - ArrowDrawable
   func constructArrow() -> Arrow {
-    let originPoint = canvas.convertPoint(link.originPoint, toView: nil)
-    let targetPoint = canvas.convertPoint(link.targetPoint, toView: nil)
-    return Arrow(p1: originPoint, p2: targetPoint)
+    return Arrow(p1: link.originPoint, p2: link.targetPoint)
   }
   
   func drawArrow() {

--- a/LinkedIdeas/LinkView.swift
+++ b/LinkedIdeas/LinkView.swift
@@ -38,7 +38,6 @@ class LinkView: NSView, CanvasElement, ArrowDrawable {
   func constructArrow() -> Arrow {
     let originPoint = canvas.convertPoint(link.originPoint, toView: nil)
     let targetPoint = canvas.convertPoint(link.targetPoint, toView: nil)
-    Swift.print("draw arrow between \(originPoint) and \(targetPoint)")
     return Arrow(p1: originPoint, p2: targetPoint)
   }
   

--- a/LinkedIdeas/LinkView.swift
+++ b/LinkedIdeas/LinkView.swift
@@ -36,7 +36,19 @@ class LinkView: NSView, CanvasElement, ArrowDrawable {
   
   // MARK: - ArrowDrawable
   func constructArrow() -> Arrow {
-    return Arrow(p1: link.originPoint, p2: link.targetPoint)
+    let originPoint = link.originPoint
+    let targetPoint = link.targetPoint
+    
+    let originRect = canvas.conceptViewFor(link.origin).frame
+    let targetRect = canvas.conceptViewFor(link.target).frame
+    
+    let intersectionPointWithOrigin = originRect.firstIntersectionTo(targetPoint)!
+    let intersectionPointWithTarget = targetRect.firstIntersectionTo(originPoint)!
+    
+    let intersectionPointWithOriginInLinkViewCoordinates = convertPoint(intersectionPointWithOrigin, fromView: canvas)
+    let intersectionPointWithTargetInLinkViewCoordinates = convertPoint(intersectionPointWithTarget, fromView: canvas)
+    
+    return Arrow(p1: intersectionPointWithOriginInLinkViewCoordinates, p2: intersectionPointWithTargetInLinkViewCoordinates)
   }
   
   func drawArrow() {

--- a/LinkedIdeasTests/CanvasViewTests.swift
+++ b/LinkedIdeasTests/CanvasViewTests.swift
@@ -28,6 +28,24 @@ class CanvasViewTests: XCTestCase {
     XCTAssertEqual(newConceptView!.textFieldSize, NSMakeSize(60, 20))
   }
   
+  func testCreatingAConcept() {
+    // when
+    let pointInCanvas = NSMakePoint(100, 200)
+    canvas.click(pointInCanvas)
+    canvas.newConceptView?.typeText("foo bar")
+    canvas.newConceptView?.pressEnterKey()
+    
+    // then
+    XCTAssertNil(canvas.newConcept)
+    XCTAssertNil(canvas.newConceptView)
+    XCTAssertEqual(canvas.concepts.count, 1)
+    
+    let concept = canvas.concepts.first!
+    let conceptView = canvas.conceptViews[concept.identifier]!
+    XCTAssertEqual(concept.point, pointInCanvas)
+    XCTAssertEqual(conceptView.frame.center, pointInCanvas)
+  }
+  
   func testClickingOnCanvasWhenOtherConceptIsEditable() {
     // given
     let concept1 = Concept(point: NSMakePoint(1, 20))

--- a/LinkedIdeasTests/CanvasViewTests.swift
+++ b/LinkedIdeasTests/CanvasViewTests.swift
@@ -90,13 +90,19 @@ class CanvasViewTests: XCTestCase {
       Concept(stringValue: "C1", point: NSMakePoint(20, 30)),
       Concept(stringValue: "C2", point: NSMakePoint(20, 30)),
     ]
+    let links = [
+      Link(origin: concepts[0], target: concepts[1])
+    ]
     canvas.concepts = concepts
+    canvas.links = links
     
     // when
     canvas.drawRect(canvas.bounds)
     
     // then
     XCTAssertEqual(canvas.conceptViews.count, 2)
+    XCTAssertEqual(canvas.linkViews.count, 1)
+    XCTAssertEqual(canvas.subviews.count, 3)
   }
   
   func testSelectTargetConceptView() {

--- a/LinkedIdeasTests/CanvasViewTests.swift
+++ b/LinkedIdeasTests/CanvasViewTests.swift
@@ -101,17 +101,33 @@ class CanvasViewTests: XCTestCase {
   
   func testSelectTargetConceptView() {
     // given
+    let concept1 = Concept(stringValue: "C1", point: NSMakePoint(120, 130))
     let concept2 = Concept(stringValue: "C2", point: NSMakePoint(220, 230))
-    canvas.concepts = [concept2]
-    let conceptView2 = ConceptView(concept: concept2, canvas: canvas)
-    canvas.conceptViews = [concept2.identifier: conceptView2]
+    canvas.concepts = [concept1, concept2]
+    canvas.drawConceptViews()
+    let conceptView2 = canvas.conceptViewFor(concept2)
     
     // when
     canvas.mode = .Links
-    let result = canvas.selectTargetConceptView(concept2.point)
+    let result = canvas.selectTargetConceptView(concept2.point, fromConcept: concept1)
     
     // then
     XCTAssertEqual(result, conceptView2)
+  }
+  
+  func testSelectTargetConceptViewInSameConcept() {
+    // given
+    let concept1 = Concept(stringValue: "C1", point: NSMakePoint(120, 130))
+    let concept2 = Concept(stringValue: "C2", point: NSMakePoint(220, 230))
+    canvas.concepts = [concept1, concept2]
+    canvas.drawConceptViews()
+    
+    // when
+    canvas.mode = .Links
+    let result = canvas.selectTargetConceptView(concept1.point, fromConcept: concept1)
+    
+    // then
+    XCTAssertNil(result)
   }
   
   func testSelectTargetConceptViewWhenNoConceptIsFound() {
@@ -123,7 +139,7 @@ class CanvasViewTests: XCTestCase {
     
     // when
     canvas.mode = .Links
-    let result = canvas.selectTargetConceptView(NSMakePoint(0, 100))
+    let result = canvas.selectTargetConceptView(NSMakePoint(0, 100), fromConcept: concept2)
     
     // then
     XCTAssertNil(result)

--- a/LinkedIdeasTests/CanvasViewTests.swift
+++ b/LinkedIdeasTests/CanvasViewTests.swift
@@ -41,7 +41,7 @@ class CanvasViewTests: XCTestCase {
     XCTAssertEqual(canvas.concepts.count, 1)
     
     let concept = canvas.concepts.first!
-    let conceptView = canvas.conceptViews[concept.identifier]!
+    let conceptView = canvas.conceptViewFor(concept)
     XCTAssertEqual(concept.point, pointInCanvas)
     XCTAssertEqual(conceptView.frame.center, pointInCanvas)
   }
@@ -81,7 +81,7 @@ class CanvasViewTests: XCTestCase {
     XCTAssertNil(canvas.newConcept)
     XCTAssertNil(canvas.newConceptView)
     XCTAssertEqual(canvas.concepts.first!.identifier, concept.identifier)
-    XCTAssertEqual(canvas.conceptViews[concept.identifier]!, conceptView)
+    XCTAssertEqual(canvas.conceptViewFor(concept), conceptView)
   }
   
   func testInitializingCanvasViewFromReadingADocument() {

--- a/LinkedIdeasTests/CanvasViewTests.swift
+++ b/LinkedIdeasTests/CanvasViewTests.swift
@@ -84,4 +84,59 @@ class CanvasViewTests: XCTestCase {
     // then
     XCTAssertEqual(canvas.conceptViews.count, 2)
   }
+  
+  func testSelectTargetConceptView() {
+    // given
+    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
+    let concept2 = Concept(stringValue: "C2", point: NSMakePoint(220, 230))
+    canvas.concepts = [concept2]
+    let conceptView2 = ConceptView(concept: concept2, canvas: canvas)
+    canvas.conceptViews = [concept2.identifier: conceptView2]
+    
+    // when
+    canvas.mode = .Links
+    let result = canvas.selectTargetConceptView(concept2.point)
+    
+    // then
+    XCTAssertEqual(result, conceptView2)
+  }
+  
+  func testSelectTargetConceptViewWhenNoConceptIsFound() {
+    // given
+    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
+    let concept2 = Concept(stringValue: "C2", point: NSMakePoint(220, 230))
+    canvas.concepts = [concept2]
+    let conceptView2 = ConceptView(concept: concept2, canvas: canvas)
+    canvas.conceptViews = [concept2.identifier: conceptView2]
+    
+    // when
+    canvas.mode = .Links
+    let result = canvas.selectTargetConceptView(NSMakePoint(0, 100))
+    
+    // then
+    XCTAssertNil(result)
+  }
+  
+  func testCreatingALinkBetweenTwoConcepts() {
+    // given
+    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
+    let concept1 = Concept(stringValue: "C1", point: NSMakePoint(20, 30))
+    let concept2 = Concept(stringValue: "C2", point: NSMakePoint(220, 230))
+    canvas.concepts = [concept1, concept2]
+    let conceptView1 = ConceptView(concept: concept1, canvas: canvas)
+    let conceptView2 = ConceptView(concept: concept2, canvas: canvas)
+    canvas.conceptViews = [
+      concept1.identifier: conceptView1,
+      concept2.identifier: conceptView2
+    ]
+    
+    // when
+    canvas.drawRect(canvas.bounds)
+    canvas.mode = Mode.Links
+    canvas.releaseMouseFromConceptView(conceptView1, point: concept2.point)
+    
+    // then
+    XCTAssertEqual(canvas.links.count, 1)
+    XCTAssertEqual(canvas.linkViews.count, 1)
+  }
 }

--- a/LinkedIdeasTests/CanvasViewTests.swift
+++ b/LinkedIdeasTests/CanvasViewTests.swift
@@ -10,10 +10,9 @@ import XCTest
 @testable import LinkedIdeas
 
 class CanvasViewTests: XCTestCase {
+  let canvas = CanvasView(frame: NSMakeRect(20, 20, 600, 400))
+  
   func testClickOnEmptyCanvas() {
-    // given
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
-    
     // when
     let clickedPoint = NSMakePoint(20, 60)
     canvas.click(clickedPoint)
@@ -33,7 +32,6 @@ class CanvasViewTests: XCTestCase {
     // given
     let concept1 = Concept(point: NSMakePoint(1, 20))
     let concept2 = Concept(point: NSMakePoint(100, 200))
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
     concept1.isEditable = true
     concept2.isEditable = true
     canvas.concepts.append(concept1)
@@ -53,7 +51,6 @@ class CanvasViewTests: XCTestCase {
   
   func testSavingAConcept() {
     // given
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
     let concept = Concept(point: NSMakePoint(100, 200))
     let conceptView = ConceptView(concept: concept, canvas: canvas)
     canvas.newConcept = concept
@@ -71,7 +68,6 @@ class CanvasViewTests: XCTestCase {
   
   func testInitializingCanvasViewFromReadingADocument() {
     // given
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
     let concepts = [
       Concept(stringValue: "C1", point: NSMakePoint(20, 30)),
       Concept(stringValue: "C2", point: NSMakePoint(20, 30)),
@@ -87,7 +83,6 @@ class CanvasViewTests: XCTestCase {
   
   func testSelectTargetConceptView() {
     // given
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
     let concept2 = Concept(stringValue: "C2", point: NSMakePoint(220, 230))
     canvas.concepts = [concept2]
     let conceptView2 = ConceptView(concept: concept2, canvas: canvas)
@@ -103,7 +98,6 @@ class CanvasViewTests: XCTestCase {
   
   func testSelectTargetConceptViewWhenNoConceptIsFound() {
     // given
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
     let concept2 = Concept(stringValue: "C2", point: NSMakePoint(220, 230))
     canvas.concepts = [concept2]
     let conceptView2 = ConceptView(concept: concept2, canvas: canvas)
@@ -119,7 +113,6 @@ class CanvasViewTests: XCTestCase {
   
   func testCreatingALinkBetweenTwoConcepts() {
     // given
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
     let concept1 = Concept(stringValue: "C1", point: NSMakePoint(20, 30))
     let concept2 = Concept(stringValue: "C2", point: NSMakePoint(220, 230))
     canvas.concepts = [concept1, concept2]

--- a/LinkedIdeasTests/ConceptViewTests.swift
+++ b/LinkedIdeasTests/ConceptViewTests.swift
@@ -73,7 +73,7 @@ class ConceptViewTests: XCTestCase {
     canvas.concepts.append(concept1)
     canvas.concepts.append(concept2)
     canvas.drawConceptViews()
-    let conceptView2 = canvas.conceptViews[concept2.identifier]!
+    let conceptView2 = canvas.conceptViewFor(concept2)
 
     // when
     canvas.click(NSMakePoint(20, 30))

--- a/LinkedIdeasTests/ConceptViewTests.swift
+++ b/LinkedIdeasTests/ConceptViewTests.swift
@@ -10,9 +10,10 @@ import XCTest
 @testable import LinkedIdeas
 
 class ConceptViewTests: XCTestCase {
+  let canvas = CanvasView(frame: NSMakeRect(20, 20, 600, 400))
+  
   func testSavingAConcept() {
     // given
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
     let concept = Concept(point: NSMakePoint(20, 30))
     let conceptView = ConceptView(concept: concept, canvas: canvas)
 
@@ -30,7 +31,6 @@ class ConceptViewTests: XCTestCase {
 
   func testTextFieldBounds() {
     // given
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
     let concept = Concept(point: NSMakePoint(20, 30))
 
     // when
@@ -42,7 +42,6 @@ class ConceptViewTests: XCTestCase {
 
   func testTextFieldBecomesFirstResponder() {
     // given
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
     let concept = Concept(point: NSMakePoint(20, 30))
     concept.isEditable = true
 
@@ -56,7 +55,6 @@ class ConceptViewTests: XCTestCase {
 
   func testClickOnConceptView() {
     // given
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
     let concept = Concept(point: NSMakePoint(20, 30))
     let conceptView = ConceptView(concept: concept, canvas: canvas)
 
@@ -71,7 +69,6 @@ class ConceptViewTests: XCTestCase {
     // given
     let concept1 = Concept(point: NSMakePoint(1, 20))
     let concept2 = Concept(point: NSMakePoint(100, 200))
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
     concept1.isEditable = true
     canvas.concepts.append(concept1)
     canvas.concepts.append(concept2)
@@ -92,7 +89,6 @@ class ConceptViewTests: XCTestCase {
 
   func testDoubleClickOnConceptView() {
     // given
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
     let concept = Concept(point: NSMakePoint(20, 30))
     let conceptView = ConceptView(concept: concept, canvas: canvas)
 
@@ -106,7 +102,6 @@ class ConceptViewTests: XCTestCase {
 
   func testDraggingAConceptView() {
     // given
-    let canvas = CanvasView(frame: NSMakeRect(20, 20, 600, 400))
     let concept = Concept(point: NSMakePoint(200, 300))
     let conceptView = ConceptView(concept: concept, canvas: canvas)
     let originalFrame = conceptView.frame
@@ -124,7 +119,6 @@ class ConceptViewTests: XCTestCase {
   
   func testDraggingAConceptViewWhenLinksModeDoesNotChangePosition() {
     // given
-    let canvas = CanvasView(frame: NSMakeRect(20, 20, 600, 400))
     let concept = Concept(point: NSMakePoint(200, 300))
     let conceptView = ConceptView(concept: concept, canvas: canvas)
     let originalFrame = conceptView.frame

--- a/LinkedIdeasTests/ConceptViewTests.swift
+++ b/LinkedIdeasTests/ConceptViewTests.swift
@@ -102,19 +102,25 @@ class ConceptViewTests: XCTestCase {
 
   func testDraggingAConceptView() {
     // given
-    let concept = Concept(point: NSMakePoint(200, 300))
+    let conceptPointInCanvas = NSMakePoint(200, 300)
+    
+    let concept = Concept(point: conceptPointInCanvas)
     let conceptView = ConceptView(concept: concept, canvas: canvas)
+    
     let originalFrame = conceptView.frame
-    let dragToPointInWindow = NSMakePoint(450, 100)
+    
+    let dragToPointInWindow = NSMakePoint(250, 150)
+    let dragToPointInCanvas = canvas.pointInCanvasCoordinates(dragToPointInWindow)
 
     // when
-    conceptView.click(NSMakePoint(200, 300))
-    conceptView.dragTo(dragToPointInWindow)
+    conceptView.click(conceptPointInCanvas)
+    conceptView.dragTo(dragToPointInCanvas)
+    
     let afterDragFrame = conceptView.frame
 
     // then
     XCTAssert(originalFrame != afterDragFrame)
-    XCTAssertEqual(afterDragFrame.center, dragToPointInWindow)
+    XCTAssertEqual(afterDragFrame.center, dragToPointInCanvas)
   }
   
   func testDraggingAConceptViewWhenLinksModeDoesNotChangePosition() {

--- a/LinkedIdeasTests/ConceptViewTests.swift
+++ b/LinkedIdeasTests/ConceptViewTests.swift
@@ -121,4 +121,22 @@ class ConceptViewTests: XCTestCase {
     XCTAssert(originalFrame != afterDragFrame)
     XCTAssertEqual(afterDragFrame.center, dragToPointInWindow)
   }
+  
+  func testDraggingAConceptViewWhenLinksModeDoesNotChangePosition() {
+    // given
+    let canvas = CanvasView(frame: NSMakeRect(20, 20, 600, 400))
+    let concept = Concept(point: NSMakePoint(200, 300))
+    let conceptView = ConceptView(concept: concept, canvas: canvas)
+    let originalFrame = conceptView.frame
+    let dragToPointInWindow = NSMakePoint(450, 100)
+    canvas.mode = Mode.Links
+    
+    // when
+    conceptView.click(NSMakePoint(200, 300))
+    conceptView.dragTo(dragToPointInWindow)
+    let afterDragFrame = conceptView.frame
+    
+    // then
+    XCTAssertEqual(originalFrame, afterDragFrame)
+  }
 }

--- a/LinkedIdeasTests/LinkTests.swift
+++ b/LinkedIdeasTests/LinkTests.swift
@@ -1,3 +1,4 @@
+
 //
 //  LinkTests.swift
 //  LinkedIdeas
@@ -11,7 +12,7 @@ import XCTest
 
 class LinkTests: XCTestCase {
   
-  func testMinimalRect() {
+  func testMinimalRectNormalCase() {
     // given
     let concept1 = Concept(point: NSMakePoint(20, 30))
     let concept2 = Concept(point: NSMakePoint(120, 130))
@@ -21,6 +22,42 @@ class LinkTests: XCTestCase {
     
     // then
     XCTAssertEqual(link.minimalRect, NSMakeRect(20, 30, 100, 100))
+  }
+  
+  func testMinimalRectWhenConceptsAreHorizontallyAligned() {
+    // given
+    let concept1 = Concept(point: NSMakePoint(300, 130))
+    let concept2 = Concept(point: NSMakePoint(120, 130))
+    
+    // when
+    let link = Link(origin: concept1, target: concept2)
+    
+    // then
+    XCTAssertEqual(link.minimalRect, NSMakeRect(120, 120, 180, 20))
+  }
+  
+  func testMinimalRectWhenConceptsAreVerticallyAligned() {
+    // given
+    let concept1 = Concept(point: NSMakePoint(300, 50))
+    let concept2 = Concept(point: NSMakePoint(300, 200))
+    
+    // when
+    let link = Link(origin: concept1, target: concept2)
+    
+    // then
+    XCTAssertEqual(link.minimalRect, NSMakeRect(290, 50, 20, 150))
+  }
+  
+  func testMinimalRectWhenConceptsAreAlmostVerticallyAligned() {
+    // given
+    let concept1 = Concept(point: NSMakePoint(305, 50))
+    let concept2 = Concept(point: NSMakePoint(300, 200))
+    
+    // when
+    let link = Link(origin: concept1, target: concept2)
+    
+    // then
+    XCTAssertEqual(link.minimalRect, NSMakeRect(290, 50, 20, 150))
   }
   
 }

--- a/LinkedIdeasTests/LinkTests.swift
+++ b/LinkedIdeasTests/LinkTests.swift
@@ -1,0 +1,14 @@
+//
+//  LinkTests.swift
+//  LinkedIdeas
+//
+//  Created by Felipe Espinoza Castillo on 26/03/16.
+//  Copyright © 2016 Felipe Espinoza Dev. All rights reserved.
+//
+
+import XCTest
+@testable import LinkedIdeas
+
+class LinkTests: XCTestCase {
+  
+}

--- a/LinkedIdeasTests/LinkTests.swift
+++ b/LinkedIdeasTests/LinkTests.swift
@@ -11,4 +11,16 @@ import XCTest
 
 class LinkTests: XCTestCase {
   
+  func testMinimalRect() {
+    // given
+    let concept1 = Concept(point: NSMakePoint(20, 30))
+    let concept2 = Concept(point: NSMakePoint(120, 130))
+    
+    // when
+    let link = Link(origin: concept1, target: concept2)
+    
+    // then
+    XCTAssertEqual(link.minimalRect, NSMakeRect(20, 30, 100, 100))
+  }
+  
 }

--- a/LinkedIdeasTests/LinkViewTests.swift
+++ b/LinkedIdeasTests/LinkViewTests.swift
@@ -29,8 +29,6 @@ class LinkViewTests: XCTestCase {
     // given
     canvas.concepts = [concept1, concept2]
     canvas.drawConceptViews()
-    let conceptView1 = canvas.conceptViewFor(concept1)
-    let conceptView2 = canvas.conceptViewFor(concept2)
     let link = Link(origin: concept1, target: concept2)
     let linkView = LinkView(link: link, canvas: canvas)
     let concept1PointInLinkViewCoordinates = NSMakePoint(40, 30)

--- a/LinkedIdeasTests/LinkViewTests.swift
+++ b/LinkedIdeasTests/LinkViewTests.swift
@@ -10,12 +10,12 @@ import XCTest
 @testable import LinkedIdeas
 
 class LinkViewTests: XCTestCase {
+  let canvas = CanvasView(frame: NSMakeRect(20, 20, 600, 400))
+  let concept1 = Concept(stringValue: "foo", point: NSMakePoint(100, 200))
+  let concept2 = Concept(stringValue: "bar", point: NSMakePoint(300, 300))
   
   func testCreateALinkView() {
     // given
-    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
-    let concept1 = Concept(stringValue: "foo", point: NSMakePoint(100, 200))
-    let concept2 = Concept(stringValue: "bar", point: NSMakePoint(300, 300))
     let link = Link(origin: concept1, target: concept2)
     
     // when
@@ -23,6 +23,29 @@ class LinkViewTests: XCTestCase {
     
     // then
     XCTAssertEqual(linkView.frame, link.minimalRect)
+  }
+  
+  func testLinkViewDrawingProportions() {
+    // given
+    canvas.concepts = [concept1, concept2]
+    canvas.drawConceptViews()
+    let conceptView1 = canvas.conceptViewFor(concept1)
+    let conceptView2 = canvas.conceptViewFor(concept2)
+    let link = Link(origin: concept1, target: concept2)
+    let linkView = LinkView(link: link, canvas: canvas)
+    let concept1PointInLinkViewCoordinates = NSMakePoint(40, 30)
+    let concept2PointInLinkViewCoordinates = NSMakePoint(200, 110)
+    
+    // when
+    let arrow = linkView.constructArrow()
+    
+    // then
+    let linkViewBoundsInCanvasCoordinates = canvas.convertRect(linkView.bounds, toView: nil)
+    XCTAssertEqual(linkView.bounds, NSMakeRect(0, 0, 200, 100))
+    XCTAssertEqual(arrow.p1, concept1PointInLinkViewCoordinates)
+    XCTAssertEqual(arrow.p2, concept2PointInLinkViewCoordinates)
+    XCTAssert(CGRectContainsPoint(linkViewBoundsInCanvasCoordinates, arrow.p1))
+    XCTAssert(CGRectContainsPoint(linkViewBoundsInCanvasCoordinates, arrow.p2))
   }
   
 }

--- a/LinkedIdeasTests/LinkViewTests.swift
+++ b/LinkedIdeasTests/LinkViewTests.swift
@@ -1,0 +1,28 @@
+//
+//  LinkViewTests.swift
+//  LinkedIdeas
+//
+//  Created by Felipe Espinoza Castillo on 26/03/16.
+//  Copyright © 2016 Felipe Espinoza Dev. All rights reserved.
+//
+
+import XCTest
+@testable import LinkedIdeas
+
+class LinkViewTests: XCTestCase {
+  
+  func testCreateALinkView() {
+    // given
+    let canvas = CanvasView(frame: NSMakeRect(0, 0, 600, 400))
+    let concept1 = Concept(stringValue: "foo", point: NSMakePoint(100, 200))
+    let concept2 = Concept(stringValue: "bar", point: NSMakePoint(300, 300))
+    let link = Link(origin: concept1, target: concept2)
+    
+    // when
+    let linkView = LinkView(link: link, canvas: canvas)
+    
+    // then
+    XCTAssertEqual(linkView.frame, link.minimalRect)
+  }
+  
+}

--- a/NSRect+PointHelpers.swift
+++ b/NSRect+PointHelpers.swift
@@ -45,4 +45,8 @@ extension NSRect {
       $0.intersectionPointWith(secondLine)
     }.filter { $0 != nil }.map { $0! }
   }
+  
+  func firstIntersectionTo(point: NSPoint) -> NSPoint? {
+    return intersectionTo(point).first
+  }
 }


### PR DESCRIPTION
The idea is to drag from 1 concept to another and create a link between them,
also being able to save that link

![screen shot 2016-03-27 at 23 32 40](https://cloud.githubusercontent.com/assets/167989/14067953/569eae0c-f474-11e5-9d0b-d2b8238423a2.png)

## Cases

- [x] change between concept/link modes
- [x] dragging from one concept to another in link mode creates a Link
- [x] dragging from one concept to nothing does not create a link
- [x] when moving a concept, the position of the link is updated
- [x] links are saved/loaded from a file

## Pending

- delete links
- add editable text to links
