### PR TITLE
Changing Mode with Keyboard shortcut

### DIFF
--- a/LinkedIdeas.xcodeproj/project.pbxproj
+++ b/LinkedIdeas.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		9BF058F91C921F7D00274A62 /* CanvasViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF058F71C921F7D00274A62 /* CanvasViewTests.swift */; };
 		9BF058FA1C921F7D00274A62 /* ConceptViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF058F81C921F7D00274A62 /* ConceptViewTests.swift */; };
 		9BF058FC1C9220F200274A62 /* ConceptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF058FB1C9220F200274A62 /* ConceptTests.swift */; };
+		9BF15C391CAC69A500C95041 /* WindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BF15C381CAC69A500C95041 /* WindowController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +75,7 @@
 		9BF058F71C921F7D00274A62 /* CanvasViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CanvasViewTests.swift; sourceTree = "<group>"; };
 		9BF058F81C921F7D00274A62 /* ConceptViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConceptViewTests.swift; sourceTree = "<group>"; };
 		9BF058FB1C9220F200274A62 /* ConceptTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConceptTests.swift; sourceTree = "<group>"; };
+		9BF15C381CAC69A500C95041 /* WindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,6 +120,7 @@
 				9B2F1D9F1BE7CFE70090CC18 /* AppDelegate.swift */,
 				9B2F1DA11BE7CFE70090CC18 /* Document.swift */,
 				9B2F1DA31BE7CFE70090CC18 /* Document.xib */,
+				9BF15C381CAC69A500C95041 /* WindowController.swift */,
 				9B2F1DA61BE7CFE70090CC18 /* Assets.xcassets */,
 				9B2F1DA81BE7CFE80090CC18 /* MainMenu.xib */,
 				9B2F1DAB1BE7CFE80090CC18 /* Info.plist */,
@@ -307,6 +310,7 @@
 				9BD2BF391C7F8B4100E8A303 /* PointInterceptable.swift in Sources */,
 				9BB8FC891CA6B889008CD6A2 /* Element.swift in Sources */,
 				9B2F1DCE1BE7D3990090CC18 /* CanvasView.swift in Sources */,
+				9BF15C391CAC69A500C95041 /* WindowController.swift in Sources */,
 				9BD2C14E1BEE6F9F00CD3C2F /* ConceptView.swift in Sources */,
 				9BD2BF3B1C7F8B5500E8A303 /* Line.swift in Sources */,
 				9BDDE7391BEF9157000AAD44 /* Concept.swift in Sources */,

--- a/LinkedIdeas/Base.lproj/Document.xib
+++ b/LinkedIdeas/Base.lproj/Document.xib
@@ -5,11 +5,12 @@
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
     </dependencies>
     <objects>
-        <customObject id="-2" userLabel="File's Owner" customClass="Document" customModule="LinkedIdeas" customModuleProvider="target">
+        <customObject id="-2" userLabel="File's Owner" customClass="WindowController" customModule="LinkedIdeas" customModuleProvider="target">
             <connections>
-                <outlet property="canvas" destination="TBv-Q1-CwE" id="B0a-cm-nHk"/>
-                <outlet property="conceptMode" destination="M5U-qj-cKy" id="EY8-jw-2RD"/>
-                <outlet property="linkMode" destination="i7N-v3-T0p" id="SKK-z1-mfR"/>
+                <outlet property="canvas" destination="TBv-Q1-CwE" id="hL5-Wd-5Lv"/>
+                <outlet property="conceptMode" destination="M5U-qj-cKy" id="Qgn-Fn-Oau"/>
+                <outlet property="linkMode" destination="i7N-v3-T0p" id="HHb-Me-GvD"/>
+                <outlet property="selectMode" destination="7v6-GU-e5B" id="WKz-LA-ejA"/>
                 <outlet property="ultraWindow" destination="xOd-HO-29H" id="y0s-jg-cSM"/>
                 <outlet property="window" destination="xOd-HO-29H" id="faa-lW-Akj"/>
             </connections>
@@ -30,14 +31,14 @@
                         <rect key="frame" x="20" y="20" width="707" height="445"/>
                         <accessibility description="canvas view" identifier="canvas"/>
                     </customView>
-                    <button translatesAutoresizingMaskIntoConstraints="NO" id="M5U-qj-cKy">
-                        <rect key="frame" x="69" y="480" width="80" height="18"/>
-                        <buttonCell key="cell" type="radio" title="Concepts" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="zDM-p1-BMN">
+                    <button tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="M5U-qj-cKy">
+                        <rect key="frame" x="139" y="480" width="80" height="18"/>
+                        <buttonCell key="cell" type="radio" title="Concepts" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="zDM-p1-BMN">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                         <connections>
-                            <action selector="changeMode:" target="-2" id="vv4-FT-zF9"/>
+                            <action selector="changeMode:" target="-2" id="Tzb-KH-5Vv"/>
                         </connections>
                     </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="V2K-jY-9vr">
@@ -48,8 +49,18 @@
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <button tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="i7N-v3-T0p">
-                        <rect key="frame" x="164" y="480" width="54" height="18"/>
+                    <button translatesAutoresizingMaskIntoConstraints="NO" id="7v6-GU-e5B">
+                        <rect key="frame" x="62" y="480" width="61" height="18"/>
+                        <buttonCell key="cell" type="radio" title="Select" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="AX3-PE-uyz">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="changeMode:" target="-2" id="bS3-pg-OHb"/>
+                        </connections>
+                    </button>
+                    <button tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="i7N-v3-T0p">
+                        <rect key="frame" x="235" y="480" width="54" height="18"/>
                         <buttonCell key="cell" type="radio" title="Links" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="BP9-Qq-X3c">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
@@ -60,16 +71,18 @@
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="i7N-v3-T0p" firstAttribute="top" secondItem="gIp-Ho-8D9" secondAttribute="top" constant="20" id="05y-fB-cSn"/>
-                    <constraint firstItem="i7N-v3-T0p" firstAttribute="leading" secondItem="M5U-qj-cKy" secondAttribute="trailing" constant="18" id="Gev-qG-VLb"/>
-                    <constraint firstItem="V2K-jY-9vr" firstAttribute="top" secondItem="gIp-Ho-8D9" secondAttribute="top" constant="19" id="Rks-0d-sQT"/>
-                    <constraint firstAttribute="bottom" secondItem="TBv-Q1-CwE" secondAttribute="bottom" constant="20" id="S9f-lF-Gwo"/>
-                    <constraint firstAttribute="trailing" secondItem="TBv-Q1-CwE" secondAttribute="trailing" constant="20" id="UhE-wA-0LK"/>
-                    <constraint firstItem="M5U-qj-cKy" firstAttribute="top" secondItem="gIp-Ho-8D9" secondAttribute="top" constant="20" id="XYG-xP-r1z"/>
-                    <constraint firstItem="V2K-jY-9vr" firstAttribute="leading" secondItem="gIp-Ho-8D9" secondAttribute="leading" constant="20" id="YDM-rw-oGK"/>
-                    <constraint firstItem="TBv-Q1-CwE" firstAttribute="leading" secondItem="gIp-Ho-8D9" secondAttribute="leading" constant="20" id="cjI-xV-H1r"/>
-                    <constraint firstItem="TBv-Q1-CwE" firstAttribute="top" secondItem="V2K-jY-9vr" secondAttribute="bottom" constant="16" id="eBr-CK-V67"/>
-                    <constraint firstItem="M5U-qj-cKy" firstAttribute="leading" secondItem="V2K-jY-9vr" secondAttribute="trailing" constant="22" id="md8-13-aWb"/>
+                    <constraint firstItem="TBv-Q1-CwE" firstAttribute="leading" secondItem="gIp-Ho-8D9" secondAttribute="leading" constant="20" id="0sY-y7-lfG"/>
+                    <constraint firstItem="7v6-GU-e5B" firstAttribute="top" secondItem="gIp-Ho-8D9" secondAttribute="top" constant="20" id="BFO-0a-jRe"/>
+                    <constraint firstItem="M5U-qj-cKy" firstAttribute="top" secondItem="gIp-Ho-8D9" secondAttribute="top" constant="20" id="I13-XB-rhJ"/>
+                    <constraint firstItem="i7N-v3-T0p" firstAttribute="top" secondItem="gIp-Ho-8D9" secondAttribute="top" constant="20" id="L8i-1R-Hed"/>
+                    <constraint firstItem="M5U-qj-cKy" firstAttribute="leading" secondItem="7v6-GU-e5B" secondAttribute="trailing" constant="19" id="LFY-Nk-QAZ"/>
+                    <constraint firstItem="7v6-GU-e5B" firstAttribute="leading" secondItem="V2K-jY-9vr" secondAttribute="trailing" constant="15" id="Rl6-4G-sDr"/>
+                    <constraint firstItem="TBv-Q1-CwE" firstAttribute="top" secondItem="7v6-GU-e5B" secondAttribute="bottom" constant="16" id="Tec-6m-Wuj"/>
+                    <constraint firstItem="V2K-jY-9vr" firstAttribute="top" secondItem="gIp-Ho-8D9" secondAttribute="top" constant="19" id="VdR-4f-Dx5"/>
+                    <constraint firstItem="V2K-jY-9vr" firstAttribute="leading" secondItem="gIp-Ho-8D9" secondAttribute="leading" constant="20" id="Xs2-x5-ZsW"/>
+                    <constraint firstAttribute="bottom" secondItem="TBv-Q1-CwE" secondAttribute="bottom" constant="20" id="fiK-ua-qHD"/>
+                    <constraint firstAttribute="trailing" secondItem="TBv-Q1-CwE" secondAttribute="trailing" constant="20" id="l9h-OU-fXG"/>
+                    <constraint firstItem="i7N-v3-T0p" firstAttribute="leading" secondItem="M5U-qj-cKy" secondAttribute="trailing" constant="19" id="zBp-2Z-IRE"/>
                 </constraints>
             </view>
             <connections>

--- a/LinkedIdeas/Base.lproj/Document.xib
+++ b/LinkedIdeas/Base.lproj/Document.xib
@@ -21,7 +21,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="133" y="235" width="747" height="517"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <value key="minSize" type="size" width="94" height="86"/>
             <view key="contentView" id="gIp-Ho-8D9">
                 <rect key="frame" x="0.0" y="0.0" width="747" height="517"/>

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -64,7 +64,7 @@ class CanvasView: NSView, Canvas {
   var newConceptView: ConceptView? = nil
   var concepts: [Concept] = [Concept]()
   var conceptViews: [String: ConceptView] = [String: ConceptView]()
-  var mode: Mode = Mode.Concepts
+  var mode: Mode = .Select
   var links: [Link] = [Link]()
   var linkViews: [String: LinkView] = [String: LinkView]()
 

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -59,19 +59,6 @@ protocol BasicCanvas {
 
 typealias Canvas = protocol<BasicCanvas, ClickableView, CanvasConceptsActions, CanvasLinkActions>
 
-// Protocol conditional extension
-extension ClickableView where Self: CanvasConceptsActions {
-  func click(point: NSPoint) {
-    markConceptsAsNotEditable()
-    unselectConcepts()
-    createConceptAt(point)
-  }
-
-  func doubleClick(point: NSPoint) {
-    click(point)
-  }
-}
-
 class CanvasView: NSView, Canvas {
   var newConcept: Concept? = nil
   var newConceptView: ConceptView? = nil
@@ -129,6 +116,18 @@ class CanvasView: NSView, Canvas {
   
   func linkViewFor(link: Link) -> LinkView {
     return linkViews[link.identifier]!
+  }
+  
+  // MARK: - ClickableView
+  
+  func click(point: NSPoint) {
+    if mode == .Concepts { createConceptAt(point) }
+    doubleClick(point)
+  }
+  
+  func doubleClick(point: NSPoint) {
+    markConceptsAsNotEditable()
+    unselectConcepts()
   }
 
   // MARK: - CanvasConceptsActions

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -213,7 +213,7 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
   // MARK: - Dragable element
   func dragTo(point: NSPoint) {
     sprint("drag")
-    if (canvas.mode == .Concepts) {
+    if (canvas.mode == .Select) {
       concept.point = point
       updateFrameToMatchConcept()
     }

--- a/LinkedIdeas/Document.swift
+++ b/LinkedIdeas/Document.swift
@@ -9,6 +9,7 @@
 import Cocoa
 
 enum Mode: String {
+  case Select = "select"
   case Concepts = "concepts"
   case Links = "links"
 }

--- a/LinkedIdeas/Document.swift
+++ b/LinkedIdeas/Document.swift
@@ -44,11 +44,6 @@ class Document: NSDocument {
   }
   
   var canvas: CanvasView!
-  
-  override func windowControllerDidLoadNib(aController: NSWindowController) {
-    super.windowControllerDidLoadNib(aController)
-    // Add any code here that needs to be executed once the windowController has loaded the document's window.
-  }
 
   override class func autosavesInPlace() -> Bool {
     return true
@@ -62,6 +57,7 @@ class Document: NSDocument {
   override func dataOfType(typeName: String) throws -> NSData {
     // Insert code here to write your document to data of the specified type. If outError != nil, ensure that you create and set an appropriate error when returning nil.
     // You can also choose to override fileWrapperOfType:error:, writeToURL:ofType:error:, or writeToURL:ofType:forSaveOperation:originalContentsURL:error: instead.
+    Swift.print("saving document..")
     documentData.writeConcepts = canvas.concepts
     documentData.writeLinks = canvas.links
     return NSKeyedArchiver.archivedDataWithRootObject(documentData)

--- a/LinkedIdeas/Document.swift
+++ b/LinkedIdeas/Document.swift
@@ -35,37 +35,27 @@ class DocumentData: NSObject, NSCoding {
 }
 
 class Document: NSDocument {
-
-  @IBOutlet weak var canvas: CanvasView!
-  @IBOutlet weak var conceptMode: NSButton!
-  @IBOutlet weak var linkMode: NSButton!
-
-  @IBOutlet var ultraWindow: NSWindow!
   var documentData = DocumentData()
-  var editionMode = Mode.Concepts
-
+  
   override init() {
     super.init()
     // Add your subclass-specific initialization here.
   }
-
+  
+  var canvas: CanvasView!
+  
   override func windowControllerDidLoadNib(aController: NSWindowController) {
     super.windowControllerDidLoadNib(aController)
     // Add any code here that needs to be executed once the windowController has loaded the document's window.
-    if let readConcepts = documentData.readConcepts { canvas.concepts = readConcepts }
-    if let readLinks = documentData.readLinks { canvas.links = readLinks }
-    canvas.mode = editionMode
-    ultraWindow.acceptsMouseMovedEvents = true
   }
 
   override class func autosavesInPlace() -> Bool {
     return true
   }
 
-  override var windowNibName: String? {
-    // Returns the nib file name of the document
-    // If you need to use a subclass of NSWindowController or if your document supports multiple NSWindowControllers, you should remove this property and override -makeWindowControllers instead.
-    return "Document"
+  override func makeWindowControllers() {
+    let windowController = WindowController(windowNibName: "Document")
+    addWindowController(windowController)
   }
 
   override func dataOfType(typeName: String) throws -> NSData {
@@ -81,14 +71,5 @@ class Document: NSDocument {
     // You can also choose to override readFromFileWrapper:ofType:error: or readFromURL:ofType:error: instead.
     // If you override either of these, you should also override -isEntireFileLoaded to return false if the contents are lazily loaded.
     documentData = NSKeyedUnarchiver.unarchiveObjectWithData(data) as! DocumentData
-  }
-
-  @IBAction func changeMode(sender: NSButton) {
-    if sender == conceptMode {
-      editionMode = .Concepts
-    } else {
-      editionMode = .Links
-    }
-    canvas.mode = editionMode
   }
 }

--- a/LinkedIdeas/WindowController.swift
+++ b/LinkedIdeas/WindowController.swift
@@ -1,0 +1,53 @@
+//
+//  WindowController.swift
+//  LinkedIdeas
+//
+//  Created by Felipe Espinoza Castillo on 30/03/16.
+//  Copyright © 2016 Felipe Espinoza Dev. All rights reserved.
+//
+
+import Cocoa
+
+class WindowController: NSWindowController {
+  @IBOutlet var ultraWindow: NSWindow!
+  @IBOutlet weak var canvas: CanvasView!
+  @IBOutlet weak var selectMode: NSButton!
+  @IBOutlet weak var conceptMode: NSButton!
+  @IBOutlet weak var linkMode: NSButton!
+  var editionMode = Mode.Concepts
+  
+  convenience init() {
+    self.init(window: nil)
+  }
+  
+  override init(window: NSWindow?) {
+    super.init(window: window)
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
+  
+  override func windowDidLoad() {
+    super.windowDidLoad()
+    ultraWindow.acceptsMouseMovedEvents = true
+    
+    let currentDocument = document as! Document
+    if let readConcepts = currentDocument.documentData.readConcepts { canvas.concepts = readConcepts }
+    if let readLinks = currentDocument.documentData.readLinks { canvas.links = readLinks }
+  }
+  
+  
+  @IBAction func changeMode(sender: NSButton) {
+    switch sender {
+    case conceptMode:
+      editionMode = .Concepts
+    case linkMode:
+      editionMode = .Links
+    default:
+      editionMode = .Select
+    }
+    Swift.print(editionMode)
+    canvas.mode = editionMode
+  }
+}

--- a/LinkedIdeas/WindowController.swift
+++ b/LinkedIdeas/WindowController.swift
@@ -35,6 +35,7 @@ class WindowController: NSWindowController {
     let currentDocument = document as! Document
     if let readConcepts = currentDocument.documentData.readConcepts { canvas.concepts = readConcepts }
     if let readLinks = currentDocument.documentData.readLinks { canvas.links = readLinks }
+    currentDocument.canvas = canvas
   }
   
   

--- a/LinkedIdeas/WindowController.swift
+++ b/LinkedIdeas/WindowController.swift
@@ -38,6 +38,22 @@ class WindowController: NSWindowController {
   }
   
   
+  // MARK: - Keyboard Events
+  override func keyDown(theEvent: NSEvent) {
+    switch theEvent.keyCode {
+    case 18:
+      canvas.mode = .Select
+      selectMode.cell?.state = 1
+    case 19:
+      canvas.mode = .Concepts
+      conceptMode.cell?.state = 1
+    case 20:
+      canvas.mode = .Links
+      linkMode.cell?.state = 1
+    default: break
+    }
+  }
+  
   @IBAction func changeMode(sender: NSButton) {
     switch sender {
     case conceptMode:

--- a/LinkedIdeasTests/CanvasViewTests.swift
+++ b/LinkedIdeasTests/CanvasViewTests.swift
@@ -12,10 +12,38 @@ import XCTest
 class CanvasViewTests: XCTestCase {
   let canvas = CanvasView(frame: NSMakeRect(20, 20, 600, 400))
   
-  func testDoubleClickOnEmptyCanvas() {
+  // MARK: - Initialization
+  
+  func testInitializingCanvasViewFromReadingADocument() {
+    // given
+    let concepts = [
+      Concept(stringValue: "C1", point: NSMakePoint(20, 30)),
+      Concept(stringValue: "C2", point: NSMakePoint(20, 30)),
+      ]
+    let links = [
+      Link(origin: concepts[0], target: concepts[1])
+    ]
+    canvas.concepts = concepts
+    canvas.links = links
+    
+    // when
+    canvas.drawRect(canvas.bounds)
+    
+    // then
+    XCTAssertEqual(canvas.conceptViews.count, 2)
+    XCTAssertEqual(canvas.linkViews.count, 1)
+    XCTAssertEqual(canvas.subviews.count, 3)
+  }
+  
+  // MARK: - Concept Mode
+  
+  func testClickOnEmptyCanvas() {
+    // given
+    canvas.mode = .Concepts
+    
     // when
     let clickedPoint = NSMakePoint(20, 60)
-    canvas.doubleClick(clickedPoint)
+    canvas.click(clickedPoint)
     
     // then
     let newConcept: Concept? = canvas.newConcept
@@ -29,9 +57,12 @@ class CanvasViewTests: XCTestCase {
   }
   
   func testCreatingAConcept() {
+    // given
+    canvas.mode = .Concepts
+    
     // when
     let pointInCanvas = NSMakePoint(100, 200)
-    canvas.doubleClick(pointInCanvas)
+    canvas.click(pointInCanvas)
     canvas.newConceptView?.typeText("foo bar")
     canvas.newConceptView?.pressEnterKey()
     
@@ -54,10 +85,11 @@ class CanvasViewTests: XCTestCase {
     concept2.isEditable = true
     canvas.concepts.append(concept1)
     canvas.concepts.append(concept2)
+    canvas.mode = .Concepts
     canvas.drawConceptViews()
     
     // when
-    canvas.doubleClick(NSMakePoint(20, 60))
+    canvas.click(NSMakePoint(20, 60))
     
     // then
     XCTAssertEqual(canvas.newConceptView!.editingString(), true)
@@ -71,6 +103,7 @@ class CanvasViewTests: XCTestCase {
     // given
     let concept = Concept(point: NSMakePoint(100, 200))
     let conceptView = ConceptView(concept: concept, canvas: canvas)
+    canvas.mode = .Concepts
     canvas.newConcept = concept
     canvas.newConceptView = conceptView
     
@@ -84,26 +117,7 @@ class CanvasViewTests: XCTestCase {
     XCTAssertEqual(canvas.conceptViewFor(concept), conceptView)
   }
   
-  func testInitializingCanvasViewFromReadingADocument() {
-    // given
-    let concepts = [
-      Concept(stringValue: "C1", point: NSMakePoint(20, 30)),
-      Concept(stringValue: "C2", point: NSMakePoint(20, 30)),
-    ]
-    let links = [
-      Link(origin: concepts[0], target: concepts[1])
-    ]
-    canvas.concepts = concepts
-    canvas.links = links
-    
-    // when
-    canvas.drawRect(canvas.bounds)
-    
-    // then
-    XCTAssertEqual(canvas.conceptViews.count, 2)
-    XCTAssertEqual(canvas.linkViews.count, 1)
-    XCTAssertEqual(canvas.subviews.count, 3)
-  }
+  // MARK: - Link Mode
   
   func testSelectTargetConceptView() {
     // given
@@ -165,11 +179,23 @@ class CanvasViewTests: XCTestCase {
     
     // when
     canvas.drawRect(canvas.bounds)
-    canvas.mode = Mode.Links
+    canvas.mode = .Links
     canvas.releaseMouseFromConceptView(conceptView1, point: concept2.point)
     
     // then
     XCTAssertEqual(canvas.links.count, 1)
     XCTAssertEqual(canvas.linkViews.count, 1)
+  }
+  
+  func testClickOnEmptyCanvasOnLinkMode() {
+    // given
+    canvas.mode = .Links
+    
+    // when
+    canvas.click(NSMakePoint(20, 60))
+    
+    // then
+    XCTAssertNil(canvas.newConcept)
+    XCTAssertNil(canvas.newConceptView)
   }
 }

--- a/LinkedIdeasTests/ConceptViewTests.swift
+++ b/LinkedIdeasTests/ConceptViewTests.swift
@@ -101,8 +101,9 @@ class ConceptViewTests: XCTestCase {
     XCTAssertEqual(conceptView.textField.stringValue, "old value")
   }
 
-  func testDraggingAConceptView() {
+  func testDraggingAConceptViewOnSelectMode() {
     // given
+    canvas.mode = .Select
     let conceptPointInCanvas = NSMakePoint(200, 300)
     
     let concept = Concept(point: conceptPointInCanvas)
@@ -122,6 +123,29 @@ class ConceptViewTests: XCTestCase {
     // then
     XCTAssert(originalFrame != afterDragFrame)
     XCTAssertEqual(afterDragFrame.center, dragToPointInCanvas)
+  }
+  
+  func testDraggingAConceptViewInAnotherModeDoesNotMoveConceptView() {
+    // given
+    canvas.mode = .Concepts
+    let conceptPointInCanvas = NSMakePoint(200, 300)
+    
+    let concept = Concept(point: conceptPointInCanvas)
+    let conceptView = ConceptView(concept: concept, canvas: canvas)
+    
+    let originalFrame = conceptView.frame
+    
+    let dragToPointInWindow = NSMakePoint(250, 150)
+    let dragToPointInCanvas = canvas.pointInCanvasCoordinates(dragToPointInWindow)
+    
+    // when
+    conceptView.click(conceptPointInCanvas)
+    conceptView.dragTo(dragToPointInCanvas)
+    
+    let afterDragFrame = conceptView.frame
+    
+    // then
+    XCTAssertEqual(originalFrame, afterDragFrame)
   }
   
   func testDraggingAConceptViewWhenLinksModeDoesNotChangePosition() {

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ way to 'explain' the connexion of ideas.
 
 - add app indicator of not saved
 - dismiss construction arrow on click
-- no concept creation on link mode
 - construction line not on same worker
 - BUG: LinkArrow when there is no intersection point with conceptViews
 - BUG: dragging fails many times when concepts has already many links
@@ -63,6 +62,5 @@ way to 'explain' the connexion of ideas.
 - aligment of concepts
 - center text
 - copy/paste/duplicate concepts/links
-- moving/select mode
 - fix size of text field when editing a concept
 - improve who holds the reference to the data, canvas or document

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ way to 'explain' the connexion of ideas.
 - [ ] delete concepts/links
 - [ ] undo/redo actions for concepts and links
 - [ ] add editable text to links
-- [ ] add color to concepts/links
+- [ ] use formatted strings for concepts/links
 - [ ] add editable curvature to links
 - [ ] zooming canvas
 - [ ] panning canvas
@@ -47,16 +47,8 @@ way to 'explain' the connexion of ideas.
   - [x] disable the editing mode of all other concepts
 - [x] concepts can be moved by drag and drop them within the canvas **undoable**
 
-#### Pending
+#### A world of ideas
 
-- selecting a concept and then pressing "delete" key will remove that concept
-  from the view and the file
-- cancelling a concept creation by pressing "ESCAPE" key
-- disable edit mode by pressing "ESCAPE" key
-
-#### A worlf of ideas
-
-- improve who holds the reference to the data, canvas or document
 - add app indicator of not saved
 - dismiss construction arrow on click
 - no concept creation on link mode
@@ -72,3 +64,4 @@ way to 'explain' the connexion of ideas.
 - copy/paste/duplicate concepts/links
 - moving/select mode
 - fix size of text field when editing a concept
+- improve who holds the reference to the data, canvas or document

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ way to 'explain' the connexion of ideas.
 - [x] moving concepts
 - [x] selecting concepts
 - [x] adding links between concepts
+- [ ] refactor: document ownership of data
 - [ ] delete concepts/links
 - [ ] undo/redo actions for concepts and links
 - [ ] add editable text to links


### PR DESCRIPTION
Add new mode `Select` which basically is for moving links and concepts around.
This should not be allowed from the `Concept` and `Link` modes.

On the canvas, pressing `1`, will set the canvas mode to `Select`, pressing
`2` will change the canvas mode to `Concepts`, and pressing `3` to `Links`
respectively.

This will allow specialized modes and easy change between them.

Changes:
--------

- [x] pressing `1,2,3` will change the current canvas mode
- [x] move only on `Select` mode
- [x] click on canvas creates concepts only on `Concept` mode
- [x] creation of links only on `Link` mode