### PR TITLE
Multi-selection of concepts for moving them

### DIFF
--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-class CanvasView: NSView, Canvas, DocumentObserver {
+class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
   var document: LinkedIdeasDocument! {
     didSet { document.observer = self }
   }
@@ -173,10 +173,8 @@ class CanvasView: NSView, Canvas, DocumentObserver {
     for concept in selectedConcepts() where concept != conceptView.concept {
       let deltaX = point.x - initialPoint.x
       let deltaY = point.y - initialPoint.y
-      let selectedConceptInitialPoint = concept.point
       let newPoint = concept.point.translate(deltaX, deltaY: deltaY)
-//      document.changeConceptPoint(concept, fromPoint: newPoint, toPoint: selectedConceptInitialPoint)
-      concept.point = newPoint
+      document.changeConceptPoint(concept, fromPoint: concept.point, toPoint: newPoint)
       let selectedConceptView = conceptViewFor(concept)
       selectedConceptView.updateFrameToMatchConcept()
       selectedConceptView.needsDisplay = true
@@ -325,5 +323,33 @@ class CanvasView: NSView, Canvas, DocumentObserver {
     Swift.print("link updated \(link)")
     let linkView = linkViewFor(link)
     linkView.needsDisplay = true
+  }
+  
+  // MARK: - DraggableElementDelegate
+  func dragStartCallback(draggableElementView: DraggableElement, dragEvent: DragEvent) {
+    let conceptView = draggableElementView as! ConceptView
+    
+    for concept in selectedConcepts() where concept != conceptView.concept {
+      let newPoint = dragEvent.translatePoint(concept.point)
+      conceptViewFor(concept).dragStart(newPoint, performCallback: false)
+    }
+  }
+  
+  func dragToCallback(draggableElementView: DraggableElement, dragEvent: DragEvent) {
+    let conceptView = draggableElementView as! ConceptView
+    
+    for concept in selectedConcepts() where concept != conceptView.concept {
+      let newPoint = dragEvent.translatePoint(concept.point)
+      conceptViewFor(concept).dragTo(newPoint, performCallback: false)
+    }
+  }
+  
+  func dragEndCallback(draggableElementView: DraggableElement, dragEvent: DragEvent) {
+    let conceptView = draggableElementView as! ConceptView
+    
+    for concept in selectedConcepts() where concept != conceptView.concept {
+      let newPoint = dragEvent.translatePoint(concept.point)
+      conceptViewFor(concept).dragEnd(newPoint, performCallback: false)
+    }
   }
 }

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -137,17 +137,28 @@ class CanvasView: NSView, Canvas, DocumentObserver {
     drawConceptViews()
   }
 
-  func clickOnConceptView(conceptView: ConceptView, point: NSPoint) {
+  func clickOnConceptView(conceptView: ConceptView, point: NSPoint, multipleSelect: Bool = false) {
     sprint("click on conceptView \(conceptView.concept.identifier) to \(point)")
-    let selectedConcept = conceptView.concept
+    let clickedConcept = conceptView.concept
+    let selectedConcepts = concepts.filter { $0.isSelected }
+    
+    let notAddingConceptsToMultipleSelect = !multipleSelect
+    let clickedConceptIsNotPartOfMultipleSelection = !selectedConcepts.contains(clickedConcept)
+    
     for concept in concepts {
-      if (concept.identifier != selectedConcept.identifier) {
-        concept.isSelected = false
+      if (concept.identifier != clickedConcept.identifier) {
+        if notAddingConceptsToMultipleSelect && clickedConceptIsNotPartOfMultipleSelection {
+          concept.isSelected = false
+        }
         concept.isEditable = false
         conceptViewFor(concept).needsDisplay = true
       }
     }
     cleanNewConcept()
+  }
+  
+  func selectedConcepts() -> [Concept] {
+    return concepts.filter { $0.isSelected }
   }
   
   var arrowOriginPoint: NSPoint?

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -164,11 +164,23 @@ class CanvasView: NSView, Canvas, DocumentObserver {
   var arrowOriginPoint: NSPoint?
   var arrowTargetPoint: NSPoint?
   
-  func dragFromConceptView(conceptView: ConceptView, point: NSPoint) {
+  func dragFromConceptView(conceptView: ConceptView, point: NSPoint, from initialPoint: NSPoint) {
     arrowOriginPoint = conceptView.concept.point
     arrowTargetPoint = point
     updateLinkViewsFor(conceptView.concept)
     needsDisplay = true
+    
+    for concept in selectedConcepts() where concept != conceptView.concept {
+      let deltaX = point.x - initialPoint.x
+      let deltaY = point.y - initialPoint.y
+      let selectedConceptInitialPoint = concept.point
+      let newPoint = concept.point.translate(deltaX, deltaY: deltaY)
+//      document.changeConceptPoint(concept, fromPoint: newPoint, toPoint: selectedConceptInitialPoint)
+      concept.point = newPoint
+      let selectedConceptView = conceptViewFor(concept)
+      selectedConceptView.updateFrameToMatchConcept()
+      selectedConceptView.needsDisplay = true
+    }
   }
   
   func releaseMouseFromConceptView(conceptView: ConceptView, point: NSPoint) {

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -86,19 +86,18 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
 
   override func mouseDragged(theEvent: NSEvent) {
     let point = pointInCanvasCoordinates(theEvent.locationInWindow)
-    if (canvas.mode == .Select) {
-      if isDragging {
-        dragTo(point)
-      } else {
-        dragStart(point)
-      }
+    if isDragging {
+      dragTo(point)
+    } else {
+      dragStart(point)
     }
   }
 
   override func mouseUp(theEvent: NSEvent) {
-    let point = pointInCanvasCoordinates(theEvent.locationInWindow)
-    if isDragging { dragEnd(point) }
-    canvas.releaseMouseFromConceptView(self, point: point)
+    if isDragging {
+      let point = pointInCanvasCoordinates(theEvent.locationInWindow)
+      dragEnd(point)
+    }
   }
   
   override func mouseEntered(theEvent: NSEvent) {
@@ -226,44 +225,48 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
   var draggableDelegate: DraggableElementDelegate? { return canvas }
   
   func dragStart(point: NSPoint, performCallback: Bool = true) {
+    initialPoint = concept.point
+    isDragging = true
+    
     if (canvas.mode == .Select) {
-      isDragging = true
-      initialPoint = concept.point
-      
       concept.point = point
       // TODO: this function should be observer from ^
+      textField.attributedStringValue = concept.attributedStringValue
       updateFrameToMatchConcept()
-      
-      if performCallback {
-        let dragEvent = DragEvent(fromPoint: initialPoint!, toPoint: point)
-        draggableDelegate?.dragStartCallback(self, dragEvent: dragEvent)
-      }
+    }
+    
+    if performCallback {
+      let dragEvent = DragEvent(fromPoint: initialPoint!, toPoint: point)
+      draggableDelegate?.dragStartCallback(self, dragEvent: dragEvent)
     }
   }
   
   func dragTo(point: NSPoint, performCallback: Bool = true) {
+    let fromPoint = concept.point
+    
     if (canvas.mode == .Select) {
-      let fromPoint = concept.point
       concept.point = point
       // TODO: this function should be observer from ^
+      textField.attributedStringValue = concept.attributedStringValue
       updateFrameToMatchConcept()
-      
-      if performCallback {
-        let dragEvent = DragEvent(fromPoint: fromPoint, toPoint: point)
-        draggableDelegate?.dragToCallback(self, dragEvent: dragEvent)
-      }
+    }
+    
+    if performCallback {
+      let dragEvent = DragEvent(fromPoint: fromPoint, toPoint: point)
+      draggableDelegate?.dragToCallback(self, dragEvent: dragEvent)
     }
   }
   
   func dragEnd(lastPoint: NSPoint, performCallback: Bool = true) {
+    let fromPoint = concept.point
+    
     if let initialPoint = initialPoint where canvas.mode == .Select {
-      let fromPoint = concept.point
       document.changeConceptPoint(concept, fromPoint: initialPoint, toPoint: lastPoint)
-      
-      if performCallback {
-        let dragEvent = DragEvent(fromPoint: fromPoint, toPoint: lastPoint)
-        draggableDelegate?.dragEndCallback(self, dragEvent: dragEvent)
-      }
+    }
+    
+    if performCallback {
+      let dragEvent = DragEvent(fromPoint: fromPoint, toPoint: lastPoint)
+      draggableDelegate?.dragEndCallback(self, dragEvent: dragEvent)
     }
     
     isDragging = false

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -224,6 +224,8 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
   // MARK: - Dragable element
   
   func dragTo(point: NSPoint, lastDrag: Bool = false) {
+    let _initialPoint = concept.point
+    
     if (canvas.mode == .Select) {
       if let initialPoint = initialPoint where lastDrag {
         document.changeConceptPoint(concept, fromPoint: initialPoint, toPoint: point)
@@ -232,7 +234,8 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
       }
       updateFrameToMatchConcept()
     }
-    canvas.dragFromConceptView(self, point: point)
+    
+    canvas.dragFromConceptView(self, point: point, from: _initialPoint)
   }
   
   // MARK: - ConceptViewProtocol

--- a/LinkedIdeas/ConceptView.swift
+++ b/LinkedIdeas/ConceptView.swift
@@ -79,7 +79,11 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
     if (theEvent.clickCount == 2) {
       doubleClick(point)
     } else {
-      click(point)
+      if (theEvent.modifierFlags.rawValue == 131330) {
+        shiftClick(point)
+      } else {
+        click(point)
+      }
     }
   }
 
@@ -142,11 +146,11 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
   // MARK: - ClickableView
   
   func click(point: NSPoint) {
-    concept.isSelected = !concept.isSelected
+    canvas.clickOnConceptView(self, point: point)
+    concept.isSelected = true //!concept.isSelected
     needsDisplay = true
     textField.attributedStringValue = concept.attributedStringValue
     updateFrameToMatchConcept()
-    canvas.clickOnConceptView(self, point: point)
     becomeFirstResponder()
   }
 
@@ -158,6 +162,14 @@ class ConceptView: NSView, NSTextFieldDelegate, StringEditableView, CanvasElemen
     updateFrameToMatchConcept()
     textField.setFrameSize(textField.intrinsicContentSize)
     canvas.clickOnConceptView(self, point: point)
+  }
+  
+  func shiftClick(point: NSPoint) {
+    concept.isSelected = !concept.isSelected
+    needsDisplay = true
+    textField.attributedStringValue = concept.attributedStringValue
+    updateFrameToMatchConcept()
+    canvas.clickOnConceptView(self, point: point, multipleSelect: true)
   }
 
   // MARK: - StringEditableView

--- a/LinkedIdeas/ElementView.swift
+++ b/LinkedIdeas/ElementView.swift
@@ -113,9 +113,7 @@ protocol CanvasConceptsActions {
   
   func drawConceptViews()
   func drawConceptView(concept: Concept)
-  func dragFromConceptView(conceptView: ConceptView, point: NSPoint, from: NSPoint)
   func clickOnConceptView(conceptView: ConceptView, point: NSPoint, multipleSelect: Bool)
-  func releaseMouseFromConceptView(conceptView: ConceptView, point: NSPoint)
   func updateLinkViewsFor(concept: Concept)
   func conceptLinksFor(concept: Concept) -> [Link]
   func isConceptSaved(concept: Concept) -> Bool

--- a/LinkedIdeas/ElementView.swift
+++ b/LinkedIdeas/ElementView.swift
@@ -73,6 +73,11 @@ protocol DraggableElement {
 protocol ClickableView {
   func click(point: NSPoint)
   func doubleClick(point: NSPoint)
+  func shiftClick(point: NSPoint)
+}
+
+extension ClickableView {
+  func shiftClick(point: NSPoint) {}
 }
 
 protocol CanvasConceptsActions {
@@ -84,8 +89,8 @@ protocol CanvasConceptsActions {
   
   func drawConceptViews()
   func drawConceptView(concept: Concept)
-  func clickOnConceptView(conceptView: ConceptView, point: NSPoint)
   func dragFromConceptView(conceptView: ConceptView, point: NSPoint)
+  func clickOnConceptView(conceptView: ConceptView, point: NSPoint, multipleSelect: Bool)
   func releaseMouseFromConceptView(conceptView: ConceptView, point: NSPoint)
   func updateLinkViewsFor(concept: Concept)
   func conceptLinksFor(concept: Concept) -> [Link]

--- a/LinkedIdeas/ElementView.swift
+++ b/LinkedIdeas/ElementView.swift
@@ -67,7 +67,31 @@ protocol ConceptViewProtocol {
 }
 
 protocol DraggableElement {
-  func dragTo(point: NSPoint, lastDrag: Bool)
+  var isDragging: Bool { get set }
+  var initialPoint: NSPoint? { get set }
+  var draggableDelegate: DraggableElementDelegate? { get }
+  
+  func dragStart(initialPoint: NSPoint, performCallback: Bool)
+  func dragTo(point: NSPoint, performCallback: Bool)
+  func dragEnd(lastPoint: NSPoint, performCallback: Bool)
+}
+
+struct DragEvent {
+  let fromPoint: NSPoint
+  let toPoint: NSPoint
+  
+  var deltaX: CGFloat { return toPoint.x - fromPoint.x }
+  var deltaY: CGFloat { return toPoint.y - fromPoint.y }
+  
+  func translatePoint(point: NSPoint) -> NSPoint {
+    return point.translate(deltaX, deltaY: deltaY)
+  }
+}
+
+protocol DraggableElementDelegate {
+  func dragStartCallback(draggableElementView: DraggableElement, dragEvent: DragEvent)
+  func dragToCallback(draggableElementView: DraggableElement, dragEvent: DragEvent)
+  func dragEndCallback(draggableElementView: DraggableElement, dragEvent: DragEvent)
 }
 
 protocol ClickableView {

--- a/LinkedIdeas/ElementView.swift
+++ b/LinkedIdeas/ElementView.swift
@@ -89,7 +89,7 @@ protocol CanvasConceptsActions {
   
   func drawConceptViews()
   func drawConceptView(concept: Concept)
-  func dragFromConceptView(conceptView: ConceptView, point: NSPoint)
+  func dragFromConceptView(conceptView: ConceptView, point: NSPoint, from: NSPoint)
   func clickOnConceptView(conceptView: ConceptView, point: NSPoint, multipleSelect: Bool)
   func releaseMouseFromConceptView(conceptView: ConceptView, point: NSPoint)
   func updateLinkViewsFor(concept: Concept)

--- a/LinkedIdeas/LinkView.swift
+++ b/LinkedIdeas/LinkView.swift
@@ -89,13 +89,11 @@ class LinkView: NSView, CanvasElement, ArrowDrawable, ClickableView, LinkViewAct
   }
   
   override func mouseEntered(theEvent: NSEvent) {
-    sprint("mouse entered")
     isHoveringView = true
     super.mouseEntered(theEvent)
   }
   
   override func mouseExited(theEvent: NSEvent) {
-    sprint("mouse exited")
     isHoveringView = false
     super.mouseExited(theEvent)
   }

--- a/LinkedIdeasTests/CanvasViewTests.swift
+++ b/LinkedIdeasTests/CanvasViewTests.swift
@@ -36,6 +36,7 @@ class TestDocument: LinkedIdeasDocument {
   }
   
   func changeConceptPoint(concept: Concept, fromPoint: NSPoint, toPoint: NSPoint) {
+    concept.point = toPoint
   }
 }
 

--- a/LinkedIdeasTests/CanvasViewTests.swift
+++ b/LinkedIdeasTests/CanvasViewTests.swift
@@ -273,4 +273,45 @@ class CanvasViewTests: XCTestCase {
     XCTAssertEqual(links.first!.isSelected, false)
     XCTAssertEqual(concepts.first!.isSelected, false)
   }
+  
+  func testMultipleSelectionOfConcepts() {
+    let concepts = [
+      Concept(stringValue: "C1", point: NSMakePoint(20, 30)),
+      Concept(stringValue: "C2", point: NSMakePoint(20, 30)),
+    ]
+    testDocument.concepts = concepts
+    concepts.first!.isSelected = true
+    canvas.drawConceptViews()
+    let conceptView2 = canvas.conceptViewFor(concepts[1])
+    canvas.mode = .Select
+    
+    // when
+    conceptView2.shiftClick(NSMakePoint(50, 60))
+    
+    // then
+    XCTAssertEqual(concepts[0].isSelected, true)
+    XCTAssertEqual(concepts[1].isSelected, true)
+  }
+  
+  func testDeselectAConceptOnMultipleSelect() {
+    let concepts = [
+      Concept(stringValue: "C1", point: NSMakePoint(20, 30)),
+      Concept(stringValue: "C2", point: NSMakePoint(20, 30)),
+    ]
+    testDocument.concepts = concepts
+    concepts[0].isSelected = true
+    concepts[1].isSelected = true
+    canvas.mode = .Select
+    canvas.drawConceptViews()
+    let conceptView2 = canvas.conceptViewFor(concepts[1])
+    
+    XCTAssertEqual(concepts[1].isSelected, true)
+    
+    // when
+    conceptView2.shiftClick(NSMakePoint(50, 60))
+    
+    // then
+    XCTAssertEqual(concepts[0].isSelected, true)
+    XCTAssertEqual(concepts[1].isSelected, false)
+  }
 }

--- a/LinkedIdeasTests/CanvasViewTests.swift
+++ b/LinkedIdeasTests/CanvasViewTests.swift
@@ -233,7 +233,7 @@ class CanvasViewTests: XCTestCase {
     // when
     canvas.drawRect(canvas.bounds)
     canvas.mode = .Links
-    canvas.releaseMouseFromConceptView(conceptView1, point: concept2.point)
+    canvas.dragEndCallback(conceptView1, dragEvent: DragEvent(fromPoint: concept1.point, toPoint: concept2.point))
     
     // then
     XCTAssertEqual(canvas.links.count, 1)
@@ -334,8 +334,8 @@ class CanvasViewTests: XCTestCase {
     let initialPoints = concepts.map { $0.point }
     let newPoint2 = NSMakePoint(120, 400) // x+20,y-50
     let newPoint3 = NSMakePoint(150, 420) // +30, +20
-    canvas.dragFromConceptView(conceptView2, point: newPoint2, from: initialPoints[1])
-    canvas.dragFromConceptView(conceptView2, point: newPoint3, from: newPoint2)
+    canvas.dragToCallback(conceptView2, dragEvent: DragEvent(fromPoint: initialPoints[1], toPoint: newPoint2))
+    canvas.dragToCallback(conceptView2, dragEvent: DragEvent(fromPoint: newPoint2, toPoint: newPoint3))
     
     // then
     XCTAssertEqual(concepts[0].point, initialPoints[0].translate(50, deltaY: -30))

--- a/LinkedIdeasTests/CanvasViewTests.swift
+++ b/LinkedIdeasTests/CanvasViewTests.swift
@@ -314,4 +314,31 @@ class CanvasViewTests: XCTestCase {
     XCTAssertEqual(concepts[0].isSelected, true)
     XCTAssertEqual(concepts[1].isSelected, false)
   }
+  
+  func testDraggingMultipleConcepts() {
+    // given
+    let concepts = [
+      Concept(stringValue: "foo", point: NSMakePoint(200, 300)),
+      Concept(stringValue: "bar", point: NSMakePoint(100, 450)),
+      Concept(stringValue: "baz", point: NSMakePoint(300, 200))
+    ]
+    testDocument.concepts = concepts
+    concepts[0].isSelected = true
+    concepts[1].isSelected = true
+    canvas.mode = .Select
+    canvas.drawConceptViews()
+    let conceptView2 = canvas.conceptViewFor(concepts[1])
+    
+    // when
+    let initialPoints = concepts.map { $0.point }
+    let newPoint2 = NSMakePoint(120, 400) // x+20,y-50
+    let newPoint3 = NSMakePoint(150, 420) // +30, +20
+    canvas.dragFromConceptView(conceptView2, point: newPoint2, from: initialPoints[1])
+    canvas.dragFromConceptView(conceptView2, point: newPoint3, from: newPoint2)
+    
+    // then
+    XCTAssertEqual(concepts[0].point, initialPoints[0].translate(50, deltaY: -30))
+    XCTAssertEqual(concepts[1].point, initialPoints[1])
+    XCTAssertEqual(concepts[2].point, initialPoints[2])
+  }
 }

--- a/LinkedIdeasTests/ConceptViewTests.swift
+++ b/LinkedIdeasTests/ConceptViewTests.swift
@@ -339,7 +339,9 @@ class ConceptViewTests: XCTestCase {
     let conceptViewsOriginalFrames = conceptViews.map { $0.frame }
     
     // when
+    conceptViews[1].dragStart(NSMakePoint(200, 450))
     conceptViews[1].dragTo(NSMakePoint(200, 450))
+    conceptViews[1].dragEnd(NSMakePoint(200, 450))
     
     // then
     let conceptViewsNewFrames = conceptViews.map { $0.frame }

--- a/LinkedIdeasTests/ConceptViewTests.swift
+++ b/LinkedIdeasTests/ConceptViewTests.swift
@@ -232,4 +232,148 @@ class ConceptViewTests: XCTestCase {
     XCTAssertEqual(canvas.linkViews.count, 1)
     XCTAssertEqual(canvas.subviews.count, 3)
   }
+  
+  // Mark: - MultipleSelect tests
+  
+  func testClickOnConceptAlreadyMultipleSelected() {
+    // Given
+    let concepts = [
+      Concept(stringValue: "foo", point: NSMakePoint(200, 300)),
+      Concept(stringValue: "bar", point: NSMakePoint(100, 450)),
+      Concept(stringValue: "baz", point: NSMakePoint(300, 200))
+    ]
+    testDocument.concepts = concepts
+    concepts[0].isSelected = true
+    concepts[1].isSelected = true
+    canvas.mode = .Select
+    canvas.drawConceptViews()
+    
+    // when
+    canvas.conceptViewFor(concepts[1]).click(NSMakePoint(20, 10))
+    
+    // then
+    XCTAssertEqual(concepts[0].isSelected, true)
+    XCTAssertEqual(concepts[1].isSelected, true)
+    XCTAssertEqual(concepts[2].isSelected, false)
+  }
+  
+  func testClickOnAnUnselectedConceptWhenThereAreOthersSelected() {
+    // Given
+    let concepts = [
+      Concept(stringValue: "foo", point: NSMakePoint(200, 300)),
+      Concept(stringValue: "bar", point: NSMakePoint(100, 450)),
+      Concept(stringValue: "baz", point: NSMakePoint(300, 200))
+    ]
+    testDocument.concepts = concepts
+    concepts[0].isSelected = true
+    concepts[1].isSelected = true
+    canvas.mode = .Select
+    canvas.drawConceptViews()
+    
+    // when
+    canvas.conceptViewFor(concepts[2]).click(NSMakePoint(20, 10))
+    
+    // then
+    XCTAssertEqual(concepts[0].isSelected, false)
+    XCTAssertEqual(concepts[1].isSelected, false)
+    XCTAssertEqual(concepts[2].isSelected, true)
+  }
+  
+  func testMultipleSelectingAConcept() {
+    // Given
+    let concepts = [
+      Concept(stringValue: "foo", point: NSMakePoint(200, 300)),
+      Concept(stringValue: "bar", point: NSMakePoint(100, 450)),
+      Concept(stringValue: "baz", point: NSMakePoint(300, 200))
+    ]
+    testDocument.concepts = concepts
+    concepts[0].isSelected = true
+    concepts[1].isSelected = true
+    canvas.mode = .Select
+    canvas.drawConceptViews()
+    
+    // when
+    canvas.conceptViewFor(concepts[2]).shiftClick(NSMakePoint(20, 10))
+    
+    // then
+    XCTAssertEqual(concepts[0].isSelected, true)
+    XCTAssertEqual(concepts[1].isSelected, true)
+    XCTAssertEqual(concepts[2].isSelected, true)
+  }
+  
+  func testDeselectingElementFromMultipleSelect() {
+    // given
+    let concepts = [
+      Concept(stringValue: "foo", point: NSMakePoint(200, 300)),
+      Concept(stringValue: "bar", point: NSMakePoint(100, 450)),
+      Concept(stringValue: "baz", point: NSMakePoint(300, 200))
+    ]
+    testDocument.concepts = concepts
+    concepts[0].isSelected = true
+    concepts[1].isSelected = true
+    canvas.mode = .Select
+    canvas.drawConceptViews()
+    
+    // when
+    canvas.conceptViewFor(concepts[1]).shiftClick(NSMakePoint(20, 10))
+    
+    // then
+    XCTAssertEqual(concepts[0].isSelected, true)
+    XCTAssertEqual(concepts[1].isSelected, false)
+    XCTAssertEqual(concepts[2].isSelected, false)
+  }
+  
+  func testDraggingMultipleSelectedConcepts() {
+    // given
+    let concepts = [
+      Concept(stringValue: "foo", point: NSMakePoint(200, 300)),
+      Concept(stringValue: "bar", point: NSMakePoint(100, 450)),
+      Concept(stringValue: "baz", point: NSMakePoint(300, 200))
+    ]
+    testDocument.concepts = concepts
+    concepts[0].isSelected = true
+    concepts[1].isSelected = true
+    canvas.mode = .Select
+    canvas.drawConceptViews()
+    let conceptViews = concepts.map { canvas.conceptViewFor($0) }
+    let conceptViewsOriginalFrames = conceptViews.map { $0.frame }
+    
+    // when
+    conceptViews[1].dragTo(NSMakePoint(200, 450))
+    
+    // then
+    let conceptViewsNewFrames = conceptViews.map { $0.frame }
+    XCTAssertNotEqual(conceptViewsOriginalFrames[0], conceptViewsNewFrames[0])
+    XCTAssertNotEqual(conceptViewsOriginalFrames[1], conceptViewsNewFrames[1])
+    XCTAssertEqual(conceptViewsOriginalFrames[2], conceptViewsNewFrames[2])
+  }
+  
+  func testDraggingConceptNotInMultipleSelect() {
+    // given
+    let concepts = [
+      Concept(stringValue: "foo", point: NSMakePoint(200, 300)),
+      Concept(stringValue: "bar", point: NSMakePoint(100, 450)),
+      Concept(stringValue: "baz", point: NSMakePoint(300, 200))
+    ]
+    testDocument.concepts = concepts
+    concepts[0].isSelected = true
+    concepts[1].isSelected = true
+    canvas.mode = .Select
+    canvas.drawConceptViews()
+    let conceptViews = concepts.map { canvas.conceptViewFor($0) }
+    let conceptViewsOriginalFrames = conceptViews.map { $0.frame }
+    
+    // when
+    conceptViews[2].click(NSMakePoint(200, 450))
+    conceptViews[2].dragTo(NSMakePoint(200, 450))
+    
+    // then
+    let conceptViewsNewFrames = conceptViews.map { $0.frame }
+    XCTAssertEqual(conceptViewsOriginalFrames[0], conceptViewsNewFrames[0])
+    XCTAssertEqual(conceptViewsOriginalFrames[1], conceptViewsNewFrames[1])
+    XCTAssertNotEqual(conceptViewsOriginalFrames[2], conceptViewsNewFrames[2])
+    XCTAssertEqual(concepts[0].isSelected, false)
+    XCTAssertEqual(concepts[1].isSelected, false)
+    XCTAssertEqual(concepts[2].isSelected, true)
+  }
 }

--- a/README.md
+++ b/README.md
@@ -29,11 +29,9 @@ way to 'explain' the connexion of ideas.
 - [ ] save canvas dimensions in document
 - [ ] reorder concepts in canvas
 - [ ] export document as image
-- [ ] support for icloud documents
 
 ## A world of ideas
 
-- add app indicator of not saved
 - dismiss construction arrow on click
 - construction line not on same worker
 - BUG: LinkArrow when there is no intersection point with conceptViews
@@ -42,8 +40,6 @@ way to 'explain' the connexion of ideas.
 - aligment of concepts
 - center text
 - copy/paste/duplicate concepts/links
-- autosave document
 - refactor conceptView/linkView use a delegate to decouple from Canvas
 - fix link views to be outside canvas ???
 - resizing of text field goes to the right
-

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ way to 'explain' the connexion of ideas.
 - [x] use formatted strings for concepts [#11](https://github.com/fespinoza/linked-ideas-osx/pull/11)
 - [x] add color to links [#12](https://github.com/fespinoza/linked-ideas-osx/pull/12)
 - [x] undo/redo actions for concepts and links [#13](https://github.com/fespinoza/linked-ideas-osx/pull/13)
-- [ ] multiple select concepts (move them)
+- [x] multiple select concepts (move them) [#14](https://github.com/fespinoza/linked-ideas-osx/pull/14)
 - [ ] align concepts
 - [ ] add editable text to links
 - [ ] add editable curvature to links


### PR DESCRIPTION
Changes:
-------

- [x] Dragging shows a rectangle and selects the elements where the mouse entered
- [x] Shift+click add to the current selection group, if the element was already selected, then it's de-selected
    - ??? on mouseUp you deselect concepts or concepts
- [x] Single click disables the multiple select
- [x] undo for multiple dragging

### Click cases

Given concepts A, B and C
And concepts A and B are selected

  When clicking on A
  Then nothing happens

  When clicking on C
  Then A and B are deselected
  Then C is selected

### Dragging cases

Given concepts A, B and C
And A and B are selected

  When dragging B
  Then A and B are moved

  When dragging C
  Then A and B are deselected
  And C is moved

### Shift click cases

Given concepts A, B and C
And A and B are selected

  When shift+click A
  Then A is deselected
  And B is still selected

  When shift+click C
  Then A, B and C are selected