### PR TITLE
Fix: problem when rendering a big document.

### DIFF
--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -12,21 +12,21 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
   var document: LinkedIdeasDocument! {
     didSet { document.observer = self }
   }
-  
+
   var newConcept: Concept? = nil
   var newConceptView: ConceptView? = nil
-  
+
   var conceptViews: [String: ConceptView] = [String: ConceptView]()
   var linkViews: [String: LinkView] = [String: LinkView]()
-  
+
   var concepts: [Concept] { return document.concepts }
   var links: [Link] { return document.links }
-  
+
   var mode: Mode = .Select
-  
+
   // MARK: - NSResponder
   override var acceptsFirstResponder: Bool { return true }
-  
+
   override var description: String {
     return "[CanvasView]"
   }
@@ -34,13 +34,13 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
   // MARK: - NSView
   let fillColor = NSColor(calibratedRed: 173/255, green: 224/255, blue: 186/255, alpha: 1)
   let borderColor = NSColor(calibratedRed: 144/255, green: 212/255, blue: 161/255, alpha: 1)
-  
+
   override func drawRect(dirtyRect: NSRect) {
     NSColor.whiteColor().set()
     NSRectFill(bounds)
     drawConceptViews()
     drawLinkViews()
-    
+
     if isDragging {
       if let initialPoint = initialPoint, endPoint = endPoint {
         let selectionRect = NSRect(p1: initialPoint, p2: endPoint)
@@ -51,25 +51,25 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
         path.stroke()
       }
     }
-    
+
     if (mode == .Links) { showConstructionArrow() }
   }
-  
+
   func containingRectFor(elements: [SquareElement]) -> NSRect {
     if (elements.isEmpty) {
       return NSMakeRect(0, 0, 900, 530)
     }
-    
+
     let minX = (elements.map { $0.rect.origin.x }).minElement()!
     let minY = (elements.map { $0.rect.origin.y }).minElement()!
     let maxX = (elements.map { $0.rect.maxX }).maxElement()!
     let maxY = (elements.map { $0.rect.maxY }).maxElement()!
     return NSMakeRect(minX, minY, maxX - minX, maxY - minY)
   }
-  
+
   let minCanvasSize = NSMakeSize(900, 530)
   let padding: CGFloat = 300.0
-  
+
   override var intrinsicContentSize: NSSize {
     let elements = concepts.map { $0 as SquareElement }
     var size = containingRectFor(elements).size
@@ -79,7 +79,7 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
   }
 
   // MARK: - MouseEvents
-  
+
   override func mouseDown(theEvent: NSEvent) {
     let clickedPoint = pointInCanvasCoordinates(theEvent.locationInWindow)
     if (theEvent.clickCount == 2) {
@@ -88,11 +88,11 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
       click(clickedPoint)
     }
   }
-  
+
   var isDragging: Bool = false
   var initialPoint: NSPoint?
   var endPoint: NSPoint?
-  
+
   override func mouseDragged(theEvent: NSEvent) {
     if (mode == .Select) {
       let point = pointInCanvasCoordinates(theEvent.locationInWindow)
@@ -112,7 +112,7 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
       }
     }
   }
-  
+
   override func mouseUp(theEvent: NSEvent) {
     if (mode == .Select) {
       isDragging = false
@@ -121,7 +121,7 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
   }
 
   // MARK: - BasicCanvas
-  
+
   func saveConcept(concept: ConceptView) {
     let _newConcept = concept.concept
     newConcept = nil
@@ -129,26 +129,26 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
     newConceptView = nil
     document.saveConcept(_newConcept)
   }
-  
+
   func pointInCanvasCoordinates(point: NSPoint) -> NSPoint {
     return convertPoint(point, fromView: nil)
   }
-  
+
   func conceptViewFor(concept: Concept) -> ConceptView {
     return conceptViews[concept.identifier]!
   }
-  
+
   func linkViewFor(link: Link) -> LinkView {
     return linkViews[link.identifier]!
   }
-  
+
   // MARK: - ClickableView
-  
+
   func click(point: NSPoint) {
     if mode == .Concepts { createConceptAt(point) }
     doubleClick(point)
   }
-  
+
   func doubleClick(point: NSPoint) {
     markConceptsAsNotEditable()
     unselectConcepts()
@@ -157,7 +157,7 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
   }
 
   // MARK: - CanvasConceptsActions
-  
+
   func drawConceptViews() {
     for concept in concepts { drawConceptView(concept) }
   }
@@ -182,15 +182,17 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
 
     newConcept = _newConcept
     newConceptView = _newConceptView
-    
+
   }
-  
+
   func createConceptViewFor(concept: Concept) -> ConceptView {
     let conceptView = ConceptView(concept: concept, canvas: self)
     conceptViews[concept.identifier] = conceptView
-    
-    addSubview(conceptView, positioned:.Above, relativeTo: nil)
-    
+
+    dispatch_async(dispatch_get_main_queue(), { [unowned self] in
+      self.addSubview(conceptView, positioned:.Above, relativeTo: nil)
+    })
+
     return conceptView
   }
 
@@ -207,10 +209,10 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
   func clickOnConceptView(conceptView: ConceptView, point: NSPoint, multipleSelect: Bool = false) {
     let clickedConcept = conceptView.concept
     let selectedConcepts = concepts.filter { $0.isSelected }
-    
+
     let notAddingConceptsToMultipleSelect = !multipleSelect
     let clickedConceptIsNotPartOfMultipleSelection = !selectedConcepts.contains(clickedConcept)
-    
+
     for concept in concepts {
       if (concept.identifier != clickedConcept.identifier) {
         if notAddingConceptsToMultipleSelect && clickedConceptIsNotPartOfMultipleSelection {
@@ -222,7 +224,7 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
     }
     cleanNewConcept()
   }
-  
+
   func selectedConcepts() -> [Concept] {
     return concepts.filter { $0.isSelected }
   }
@@ -232,17 +234,17 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
     newConceptView = nil
     newConcept = nil
   }
-  
+
   func updateLinkViewsFor(concept: Concept) {
     for link in conceptLinksFor(concept) {
       linkViewFor(link).frame = link.rect
     }
   }
-  
+
   func isConceptSaved(concept: Concept) -> Bool {
     return concept != newConcept
   }
-  
+
   func justRemoveConceptView(conceptView: ConceptView) {
     let concept = conceptView.concept
     conceptViews.removeValueForKey(concept.identifier)
@@ -251,26 +253,26 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
 
     for link in conceptLinksFor(concept) { removeLinkView(linkViewFor(link)) }
   }
-  
+
   func removeConceptView(conceptView: ConceptView) {
     let concept = conceptView.concept
     document.removeConcept(concept)
     justRemoveConceptView(conceptView)
   }
-  
+
   func conceptLinksFor(concept: Concept) -> [Link] {
     return links.filter {
       return $0.origin.identifier == concept.identifier ||
         $0.target.identifier == concept.identifier
     }
   }
-  
+
   // MARK: - CanvasLinkActions
-  
+
   func drawLinkViews() {
     for link in links { drawLinkView(link) }
   }
-  
+
   func drawLinkView(link: Link) {
     if let linkView = linkViews[link.identifier] {
       linkView.needsDisplay = true
@@ -280,7 +282,7 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
       linkViews[link.identifier] = linkView
     }
   }
-  
+
   func showConstructionArrow() {
     if let arrowOriginPoint = arrowOriginPoint, arrowTargetPoint = arrowTargetPoint {
       NSColor.blueColor().set()
@@ -288,12 +290,12 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
       arrow.bezierPath().fill()
     }
   }
-  
+
   func removeConstructionArrow() {
     arrowOriginPoint = nil
     arrowTargetPoint = nil
   }
-  
+
   func selectTargetConceptView(point: NSPoint, fromConcept originConcept: Concept) -> ConceptView? {
     for (_, conceptView) in conceptViews {
       if (mode == .Links && conceptView.concept != originConcept && CGRectContainsPoint(conceptView.frame, point)) {
@@ -303,14 +305,14 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
 
     return nil
   }
-  
+
   func createLinkBetweenConceptsViews(originConceptView: ConceptView, targetConceptView: ConceptView) {
     let link = Link(origin: originConceptView.concept, target: targetConceptView.concept)
-    
+
     if let windowController = window?.windowController as? WindowController {
       link.color = windowController.selectedColor
     }
-    
+
     document.saveLink(link)
   }
 
@@ -319,98 +321,98 @@ class CanvasView: NSView, Canvas, DocumentObserver, DraggableElementDelegate {
     document.removeLink(link)
     justRemoveLinkView(linkView)
   }
-  
+
   func justRemoveLinkView(linkView: LinkView) {
     linkViews.removeValueForKey(linkView.link.identifier)
     linkView.removeFromSuperview()
   }
-  
+
   func unselectLinks() {
     for link in links { link.isSelected = false }
     drawLinkViews()
   }
-  
+
   // MARK: - DocumentObserver
   func conceptAdded(concept: Concept) {
     createConceptViewFor(concept)
   }
-  
+
   func conceptRemoved(concept: Concept) {
     justRemoveConceptView(conceptViewFor(concept))
   }
-  
+
   func conceptUpdated(concept: Concept) {
     let conceptView = conceptViewFor(concept)
     conceptView.updateFrameToMatchConcept()
     conceptView.needsDisplay = true
     updateLinkViewsFor(concept)
   }
-  
+
   func linkAdded(link: Link) {
     drawLinkView(link)
   }
-  
+
   func linkRemoved(link: Link) {
     justRemoveLinkView(linkViewFor(link))
   }
-  
+
   func linkUpdated(link: Link) {
     let linkView = linkViewFor(link)
     linkView.needsDisplay = true
   }
-  
+
   // MARK: - DraggableElementDelegate
   func dragStartCallback(draggableElementView: DraggableElement, dragEvent: DragEvent) {
     let conceptView = draggableElementView as! ConceptView
-    
+
     if (mode == .Select) {
       for concept in selectedConcepts() where concept != conceptView.concept {
         let newPoint = dragEvent.translatePoint(concept.point)
         conceptViewFor(concept).dragStart(newPoint, performCallback: false)
       }
     }
-    
+
     if (mode == .Links) {
       arrowOriginPoint = conceptView.concept.point
     }
   }
-  
+
   func dragToCallback(draggableElementView: DraggableElement, dragEvent: DragEvent) {
     let conceptView = draggableElementView as! ConceptView
-    
+
     if (mode == .Select) {
       for concept in selectedConcepts() where concept != conceptView.concept {
         let newPoint = dragEvent.translatePoint(concept.point)
         conceptViewFor(concept).dragTo(newPoint, performCallback: false)
       }
     }
-    
+
     if (mode == .Links) {
       arrowTargetPoint = dragEvent.toPoint
       needsDisplay = true
     }
-    
+
     updateLinkViewsFor(conceptView.concept)
   }
-  
+
   var arrowOriginPoint: NSPoint?
   var arrowTargetPoint: NSPoint?
-  
+
   func dragEndCallback(draggableElementView: DraggableElement, dragEvent: DragEvent) {
     let conceptView = draggableElementView as! ConceptView
-    
+
     if (mode == .Select) {
       for concept in selectedConcepts() where concept != conceptView.concept {
         let newPoint = dragEvent.translatePoint(concept.point)
         conceptViewFor(concept).dragEnd(newPoint, performCallback: false)
       }
     }
-    
+
     if (mode == .Links) {
       if let targetedConceptView = selectTargetConceptView(dragEvent.toPoint, fromConcept: conceptView.concept) {
         createLinkBetweenConceptsViews(conceptView, targetConceptView: targetedConceptView)
       }
-      
+
       removeConstructionArrow()
     }
   }


### PR DESCRIPTION
For big documents, like my goals and stuff like that i get the following
error:

```
27/06/16 18:22:16,060 LinkedIdeas[1606]: This application is modifying the autolayout engine from a background thread, which can lead to engine corruption and weird crashes.  This will cause an exception in a future release.
 Stack:(
	0   CoreFoundation                      0x00007fff88daa4f2 __exceptionPreprocess + 178
	1   libobjc.A.dylib                     0x00007fff8cd15f7e objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff88e114bd +[NSException raise:format:] + 205
	3   Foundation                          0x00007fff994571f1 _AssertAutolayoutOnMainThreadOnly + 79
	4   Foundation                          0x00007fff99457046 -[NSISEngine withBehaviors:performModifications:] + 31
	5   AppKit                              0x00007fff98781a8a -[NSView(NSConstraintBasedLayout) _withAutomaticEngineOptimizationDisabled:] + 70
	6   AppKit                              0x00007fff98815ec6 __52-[NSView(NSConstraintBasedLayout) _setLayoutEngine:]_block_invoke + 485
	7   AppKit                              0x00007fff9878c7ee -[NSView(NSConstraintBasedLayout) _setLayoutEngine:] + 233
	8   AppKit                              0x00007fff9878152d -[NSView _setSuperview:] + 2177
	9   AppKit                              0x00007fff98780814 -[NSView addSubview:] + 448
	10  AppKit                              0x00007fff987be4fc -[NSView addSubview:positioned:relativeTo:] + 211
	11  LinkedIdeas                         0x00000001000231ae _TFC11LinkedIdeas10CanvasView20createConceptViewForfCS_7ConceptCS_11ConceptView + 542
	12  LinkedIdeas                         0x0000000100022c8b _TFC11LinkedIdeas10CanvasView15drawConceptViewfCS_7ConceptT_ + 459
	13  LinkedIdeas                         0x0000000100022a4a _TFC11LinkedIdeas10CanvasView16drawConceptViewsfT_T_ + 586
	14  LinkedIdeas                         0x000000010001ee71 _TFC11LinkedIdeas10CanvasView8drawRectfVSC6CGRectT_ + 337
	15  LinkedIdeas                         0x000000010001f355 _TToFC11LinkedIdeas10CanvasView8drawRectfVSC6CGRectT_ + 117
	16  AppKit                              0x00007fff98905cd2 -[NSView _drawRect:clip:] + 3626
	17  AppKit                              0x00007fff9902fb35 -[_NSViewDrawOperation main] + 241
	18  Foundation                          0x00007fff9943ac7a -[__NSOperationInternal _start:] + 654
	19  Foundation                          0x00007fff99436c64 __NSOQSchedule_f + 194
	20  libdispatch.dylib                   0x0000000100769cc5 _dispatch_client_callout + 8
	21  libdispatch.dylib                   0x000000010076f112 _dispatch_queue_drain + 351
	22  libdispatch.dylib                   0x0000000100776e24 _dispatch_queue_invoke + 557
	23  libdispatch.dylib                   0x000000010076ddab _dispatch_root_queue_drain + 1226
	24  libdispatch.dylib                   0x000000010076d8a5 _dispatch_worker_thread3 + 106
	25  libsystem_pthread.dylib             0x00000001007cc336 _pthread_wqthread + 1129
	26  libsystem_pthread.dylib             0x00000001007c9f91 start_wqthread + 13
)
```

In my code the line that caused the problem was:

```swift
// /LinkedIdeas/CanvasView.swift b/LinkedIdeas/CanvasView.swift

func createConceptViewFor(concept: Concept) -> ConceptView {
 let conceptView = ConceptView(concept: concept, canvas: self)
 conceptViews[concept.identifier] = conceptView

  addSubview(conceptView, positioned:.Above, relativeTo: nil)

 return conceptView
}
```

the `addSubview` call was failing. After some googling around I found
the same situation here:

http://stackoverflow.com/questions/28302019/getting-a-this-application-is-modifying-the-autolayout-engine-error

On which I applied this commit.

The problem is that **I don't understand the problem**, as I am not sure
why this call is executed in the background, but after applying this
patch I don't get the error anymore.