### PR TITLE
Shift+click concepts adds them to the group selection.

### DIFF
--- a/LinkedIdeas/CanvasViewController+MouseEvents.swift
+++ b/LinkedIdeas/CanvasViewController+MouseEvents.swift
@@ -11,6 +11,7 @@ import Cocoa
 // MARK: - CanvasViewController+MouseEvents
 
 extension CanvasViewController {
+  // MARK: - Mouse Events
   override func mouseDown(with event: NSEvent) {
     let point = convertToCanvasCoordinates(point: event.locationInWindow)
 
@@ -18,21 +19,21 @@ extension CanvasViewController {
       if let clickedElements = clickedElements(atPoint: point) {
         switch currentState {
         case .selectedElement(let selectedElement):
-          if !event.modifierFlags.contains(.shift) || (selectedElement as? Link) != nil {
+          if !isPressingShift(event: event) || (selectedElement as? Link) != nil {
             // single click, select another element
             safeTransiton {
               try stateManager.toSelectedElement(element: clickedElements.first!)
             }
           }
-          // else: it can be additional selection or link creation
+        // else: it can be additional selection or link creation
         case .multipleSelectedElements:
           // do nothing, because it's the init of multiple drag
           break
         default:
-            // by default clicking (or shift clicking) an element selects it.
-            safeTransiton {
-              try stateManager.toSelectedElement(element: clickedElements.first!)
-            }
+          // by default clicking (or shift clicking) an element selects it.
+          safeTransiton {
+            try stateManager.toSelectedElement(element: clickedElements.first!)
+          }
         }
 
       } else {
@@ -83,7 +84,8 @@ extension CanvasViewController {
       guard let concepts = elements as? [Concept] else {
         return
       }
-      if !event.modifierFlags.contains(.shift) {
+
+      if !isPressingShift(event: event) {
         drag(concepts: concepts, toPoint: point)
       }
 
@@ -108,40 +110,23 @@ extension CanvasViewController {
 
       if didDragStart() {
         if isDragShiftEvent(event) {
-          if let targetConcept = clickedSingleConcept(atPoint: point) {
-            targetConcept.isSelected = false
-
-            let link = saveLink(fromConcept: concept, toConcept: targetConcept)
-            dismissConstructionArrow()
-            safeTransiton {
-              try stateManager.toSelectedElement(element: link)
-            }
-          } else {
-            safeTransiton { try stateManager.toCanvasWaiting() }
-          }
+          whenClickedOnSingleConcept(atPoint: point, thenDo: { (targetConcept) in
+            createNewLinkUp(fromConcept: concept, toConcept: targetConcept)
+          })
         } else {
           endDrag(forConcept: concept, toPoint: point)
         }
       } else {
         // click
-        if let targetConcept = clickedSingleConcept(atPoint: point) {
+        whenClickedOnSingleConcept(atPoint: point, thenDo: { (targetConcept) in
           // shift + click on concept
-          if event.modifierFlags.contains(.shift) {
-            let elements = [element, targetConcept]
-            if (element as? Concept) != targetConcept {
-              safeTransiton {
-                try stateManager.toMultipleSelectedElements(elements: elements)
-              }
-            } else {
-              safeTransiton { try stateManager.toCanvasWaiting() }
-            }
+          if isPressingShift(event: event) {
+            shiftClickUp(onConcept: targetConcept, withSelectedElement: element)
           }
           // else: just single click on concept, do nothing
-        } else {
-          safeTransiton { try stateManager.toCanvasWaiting() }
-        }
+        })
       }
-    case .multipleSelectedElements(var elements):
+    case .multipleSelectedElements(let elements):
       guard let concepts = elements as? [Concept] else {
         return
       }
@@ -150,36 +135,9 @@ extension CanvasViewController {
         endDrag(forConcepts: concepts, toPoint: point)
       } else {
         // shift+click
-        if let targetConcept = clickedSingleConcept(atPoint: point) {
-          let elementAlreadySelected = elements.contains(where: { (element) -> Bool in
-            return (element as? Concept) == targetConcept
-          })
-
-          if elementAlreadySelected {
-            // unselect from group
-            elements.remove(at: elements.index(where: { (element) -> Bool in
-              return (element as? Concept) == targetConcept
-            })!)
-
-            if elements.count > 1 {
-              safeTransiton {
-                try stateManager.toMultipleSelectedElements(elements: elements)
-              }
-            } else {
-              safeTransiton {
-                try stateManager.toSelectedElement(element: elements.first!)
-              }
-            }
-          } else {
-            elements.append(targetConcept)
-
-            safeTransiton {
-              try stateManager.toMultipleSelectedElements(elements: elements)
-            }
-          }
-        } else {
-          safeTransiton { try stateManager.toCanvasWaiting() }
-        }
+        whenClickedOnSingleConcept(atPoint: point, thenDo: { (targetConcept) in
+          shiftClickUp(onConcept: targetConcept, withSelectedElements: elements)
+        })
       }
     case .canvasWaiting:
       selectHoveredConcepts()
@@ -189,5 +147,73 @@ extension CanvasViewController {
     }
 
     resetDraggingConcepts()
+  }
+
+  // MARK: - mouse action helpers
+
+  private func isPressingShift(event: NSEvent) -> Bool {
+    return event.modifierFlags.contains(.shift)
+  }
+
+  private func createNewLinkUp(fromConcept: Concept, toConcept: Concept) {
+    toConcept.isSelected = false
+
+    let link = saveLink(fromConcept: fromConcept, toConcept: toConcept)
+    dismissConstructionArrow()
+    safeTransiton {
+      try stateManager.toSelectedElement(element: link)
+    }
+  }
+
+  private func shiftClickUp(onConcept targetConcept: Concept, withSelectedElements elements: [Element]) {
+    guard var concepts = elements as? [Concept] else {
+      return
+    }
+
+    if concepts.contains(targetConcept) {
+      // unselect from group
+      concepts.remove(at: concepts.index(of: targetConcept)!)
+
+      if concepts.count > 1 {
+        safeTransiton {
+          try stateManager.toMultipleSelectedElements(elements: concepts)
+        }
+      } else {
+        safeTransiton {
+          try stateManager.toSelectedElement(element: concepts.first!)
+        }
+      }
+    } else {
+      concepts.append(targetConcept)
+
+      safeTransiton {
+        try stateManager.toMultipleSelectedElements(elements: concepts)
+      }
+    }
+  }
+
+  private func shiftClickUp(onConcept targetConcept: Concept, withSelectedElement element: Element) {
+    let elements = [element, targetConcept]
+    if (element as? Concept) != targetConcept {
+      safeTransiton {
+        try stateManager.toMultipleSelectedElements(elements: elements)
+      }
+    } else {
+      safeTransiton { try stateManager.toCanvasWaiting() }
+    }
+  }
+
+  /// handles the common case of evaluating if the clicked point matches a single concept then do some logic, otherwise
+  /// it will transition to .canvasWaiting
+  ///
+  /// - Parameters:
+  ///   - point: point from the click event
+  ///   - thenDo: what actions you want to perform when there was actually a clicked concept
+  private func whenClickedOnSingleConcept(atPoint point: NSPoint, thenDo: (Concept) -> Void) {
+    if let targetConcept = clickedSingleConcept(atPoint: point) {
+      thenDo(targetConcept)
+    } else {
+      safeTransiton { try stateManager.toCanvasWaiting() }
+    }
   }
 }

--- a/LinkedIdeas/CanvasViewController+MouseEvents.swift
+++ b/LinkedIdeas/CanvasViewController+MouseEvents.swift
@@ -16,17 +16,30 @@ extension CanvasViewController {
 
     if event.isSingleClick() {
       if let clickedElements = clickedElements(atPoint: point) {
-        if !currentState.isSimilar(to: .multipleSelectedElements(elements: [Element]())) {
-          safeTransiton {
-            try stateManager.toSelectedElement(element: clickedElements.first!)
+        switch currentState {
+        case .selectedElement:
+          if !event.modifierFlags.contains(.shift) {
+            // single click, select another element
+            safeTransiton {
+              try stateManager.toSelectedElement(element: clickedElements.first!)
+            }
           }
+          // else: it can be additional selection or link creation
+        case .multipleSelectedElements:
+          // do nothing, because it's the init of multiple drag
+          break
+        default:
+            // by default clicking (or shift clicking) an element selects it.
+            safeTransiton {
+              try stateManager.toSelectedElement(element: clickedElements.first!)
+            }
         }
 
       } else {
+        // if no concepts are clicked, then go to canvasWaiting
         safeTransiton {
           try stateManager.toCanvasWaiting()
         }
-
       }
     } else if event.isDoubleClick() {
       if let element = clickedSingleElement(atPoint: point) {
@@ -51,12 +64,16 @@ extension CanvasViewController {
       }
 
       if isDragShiftEvent(event) {
-        creationArrowForLink(toPoint: point)
-        didShiftDragStart = true
-        if let hoveredConcepts = clickedConcepts(atPoint: point) {
-          select(elements: hoveredConcepts)
+        if dragCount > 1 {
+          creationArrowForLink(toPoint: point)
+          didShiftDragStart = true
+          if let hoveredConcepts = clickedConcepts(atPoint: point) {
+            select(elements: hoveredConcepts)
+          } else {
+            unselect(elements: document.concepts.filter { $0 != concept })
+          }
         } else {
-          unselect(elements: document.concepts.filter { $0 != concept })
+          dragCount += 1
         }
       } else {
         drag(concept: concept, toPoint: point)
@@ -66,7 +83,9 @@ extension CanvasViewController {
       guard let concepts = elements as? [Concept] else {
         return
       }
-      drag(concepts: concepts, toPoint: point)
+      if !event.modifierFlags.contains(.shift) {
+        drag(concepts: concepts, toPoint: point)
+      }
 
     case .canvasWaiting:
       hoverConcepts(toPoint: point)
@@ -83,31 +102,85 @@ extension CanvasViewController {
 
     switch currentState {
     case .selectedElement(let element):
-      guard let concept = element as? Concept, didDragStart() else {
+      guard let concept = element as? Concept else {
         return
       }
 
-      if isDragShiftEvent(event) {
-        if let targetConcept = clickedSingleConcept(atPoint: point) {
-          targetConcept.isSelected = false
+      if didDragStart() {
+        if isDragShiftEvent(event) {
+          if let targetConcept = clickedSingleConcept(atPoint: point) {
+            targetConcept.isSelected = false
 
-          let link = saveLink(fromConcept: concept, toConcept: targetConcept)
-          dismissConstructionArrow()
-          safeTransiton {
-            try stateManager.toSelectedElement(element: link)
+            let link = saveLink(fromConcept: concept, toConcept: targetConcept)
+            dismissConstructionArrow()
+            safeTransiton {
+              try stateManager.toSelectedElement(element: link)
+            }
+          } else {
+            safeTransiton { try stateManager.toCanvasWaiting() }
+          }
+        } else {
+          endDrag(forConcept: concept, toPoint: point)
+        }
+      } else {
+        // click
+        if let targetConcept = clickedSingleConcept(atPoint: point) {
+          // shift + click on concept
+          if event.modifierFlags.contains(.shift) {
+            let elements = [element, targetConcept]
+            if (element as? Concept) != targetConcept {
+              safeTransiton {
+                try stateManager.toMultipleSelectedElements(elements: elements)
+              }
+            } else {
+              safeTransiton { try stateManager.toCanvasWaiting() }
+            }
+          }
+          // else: just single click on concept, do nothing
+        } else {
+          safeTransiton { try stateManager.toCanvasWaiting() }
+        }
+      }
+    case .multipleSelectedElements(var elements):
+      guard let concepts = elements as? [Concept] else {
+        return
+      }
+
+      if didDragStart() {
+        endDrag(forConcepts: concepts, toPoint: point)
+      } else {
+        // shift+click
+        if let targetConcept = clickedSingleConcept(atPoint: point) {
+          let elementAlreadySelected = elements.contains(where: { (element) -> Bool in
+            return (element as? Concept) == targetConcept
+          })
+
+          if elementAlreadySelected {
+            // unselect from group
+            elements.remove(at: elements.index(where: { (element) -> Bool in
+              return (element as? Concept) == targetConcept
+            })!)
+
+            if elements.count > 1 {
+              safeTransiton {
+                try stateManager.toMultipleSelectedElements(elements: elements)
+              }
+            } else {
+              safeTransiton {
+                try stateManager.toSelectedElement(element: elements.first!)
+              }
+            }
+          } else {
+            elements.append(targetConcept)
+
+            safeTransiton {
+              try stateManager.toMultipleSelectedElements(elements: elements)
+            }
           }
         } else {
           safeTransiton { try stateManager.toCanvasWaiting() }
         }
-      } else {
-        endDrag(forConcept: concept, toPoint: point)
       }
-    case .multipleSelectedElements(let elements):
-      guard let concepts = elements as? [Concept] else {
-        return
-      }
-      endDrag(forConcepts: concepts, toPoint: point)
-
     case .canvasWaiting:
       selectHoveredConcepts()
 

--- a/LinkedIdeas/CanvasViewController+MouseEvents.swift
+++ b/LinkedIdeas/CanvasViewController+MouseEvents.swift
@@ -17,8 +17,8 @@ extension CanvasViewController {
     if event.isSingleClick() {
       if let clickedElements = clickedElements(atPoint: point) {
         switch currentState {
-        case .selectedElement:
-          if !event.modifierFlags.contains(.shift) {
+        case .selectedElement(let selectedElement):
+          if !event.modifierFlags.contains(.shift) || (selectedElement as? Link) != nil {
             // single click, select another element
             safeTransiton {
               try stateManager.toSelectedElement(element: clickedElements.first!)

--- a/LinkedIdeas/StateManager.swift
+++ b/LinkedIdeas/StateManager.swift
@@ -146,7 +146,8 @@ struct StateManager {
       .canvasWaiting,
       .newConcept(point: NSPoint.zero),
       .selectedElement(element: EmptyElement.example),
-      .editingElement(element: EmptyElement.example)
+      .editingElement(element: EmptyElement.example),
+      .multipleSelectedElements(elements: [Element]())
     ]
 
     let state = CanvasState.selectedElement(element: element)

--- a/LinkedIdeas/StateManager.swift
+++ b/LinkedIdeas/StateManager.swift
@@ -170,6 +170,7 @@ struct StateManager {
   public mutating func toMultipleSelectedElements(elements: [Element]) throws {
     let possibleStates: [CanvasState] = [
       .canvasWaiting,
+      .selectedElement(element: EmptyElement.example),
       .multipleSelectedElements(elements: [Element]())
     ]
 

--- a/LinkedIdeasTests/CanvasViewControllerTests.swift
+++ b/LinkedIdeasTests/CanvasViewControllerTests.swift
@@ -227,6 +227,45 @@ extension CanvasViewControllerTests {
       XCTFail("current state should be selected element")
     }
   }
+
+  func testShiftDragFromOneConceptToAnotherToCreateLinkWhenAnotherLinkIsSelected() {
+    let concepts = [
+      Concept(stringValue: "Random", point: NSPoint(x: 20, y: 600)),
+      Concept(stringValue: "Foo bar", point: NSPoint(x: 600, y: 800)),
+      Concept(stringValue: "Another", point: NSPoint(x: 300, y: 400))
+    ]
+    concepts.forEach {
+      document.concepts.append($0)
+    }
+    let link = Link(origin: concepts[0], target: concepts[1])
+    document.links.append(link)
+
+    canvasViewController.currentState = .selectedElement(element: link)
+
+    canvasViewController.mouseDown(
+      with: createMouseEvent(clickCount: 1, location: concepts[1].point, shift: true)
+    )
+    canvasViewController.mouseDragged(
+      with: createMouseEvent(
+        clickCount: 1,
+        location: concepts[1].point.translate(deltaX: 10, deltaY: 20),
+        shift: true
+      )
+    )
+    canvasViewController.mouseDragged(with: createMouseEvent(clickCount: 1, location: concepts[2].point, shift: true))
+    canvasViewController.mouseUp(with: createMouseEvent(clickCount: 1, location: concepts[2].point, shift: true))
+
+    switch canvasViewController.currentState {
+    case .selectedElement(let element):
+      if let selectedLink = element as? Link {
+        XCTAssertNotEqual(selectedLink, link)
+      } else {
+        XCTFail("a link should have been created an selected")
+      }
+    default:
+      XCTFail("current state should be selected element")
+    }
+  }
 }
 
 // MARK - CanvasViewControllers: TextField Delegate Tests


### PR DESCRIPTION
# Changes:

- Extract implementation details from mouse* methods.
  so then there are custom helper functions that make the necessary actions
  after detecting a particular kind of event.

- Allow creating a link when another link is selected.

- Support shift+click to select/deselect multiple elements.
  this just makes it work, next, make it pretty.

- You can select multiple elements from single selected.

- You can select single element from multiple selected.