### PR TITLE
Copy/paste support.

### DIFF
--- a/LinkedIdeas.xcodeproj/project.pbxproj
+++ b/LinkedIdeas.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		9BA63D321D74C38400EBC3AD /* CanvasViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA63D311D74C38400EBC3AD /* CanvasViewController.swift */; };
 		9BA63D351D74C47800EBC3AD /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA63D341D74C47800EBC3AD /* CanvasView.swift */; };
 		9BABB2B21C07B7F7001EC9E0 /* Link.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BABB2B11C07B7F7001EC9E0 /* Link.swift */; };
+		9BB677681ED47FB500B1AF83 /* CanvasViewController+NSPasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB677671ED47FB500B1AF83 /* CanvasViewController+NSPasteboard.swift */; };
 		9BB8FC831CA6B7D7008CD6A2 /* LinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB8FC821CA6B7D7008CD6A2 /* LinkTests.swift */; };
 		9BB8FC891CA6B889008CD6A2 /* Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB8FC881CA6B889008CD6A2 /* Element.swift */; };
 		9BC8587F1EC4F692003B3EFF /* CanvasViewController+MenuActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC8587E1EC4F692003B3EFF /* CanvasViewController+MenuActions.swift */; };
@@ -116,6 +117,7 @@
 		9BA63D311D74C38400EBC3AD /* CanvasViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = CanvasViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		9BA63D341D74C47800EBC3AD /* CanvasView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = CanvasView.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		9BABB2B11C07B7F7001EC9E0 /* Link.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Link.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		9BB677671ED47FB500B1AF83 /* CanvasViewController+NSPasteboard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CanvasViewController+NSPasteboard.swift"; sourceTree = "<group>"; };
 		9BB8FC821CA6B7D7008CD6A2 /* LinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkTests.swift; sourceTree = "<group>"; };
 		9BB8FC881CA6B889008CD6A2 /* Element.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Element.swift; sourceTree = "<group>"; };
 		9BC8587E1EC4F692003B3EFF /* CanvasViewController+MenuActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CanvasViewController+MenuActions.swift"; sourceTree = "<group>"; };
@@ -260,6 +262,7 @@
 				9B3941A11E5658F500F1E957 /* CanvasViewController+CanvasViewDataSource.swift */,
 				9B3941A31E56591900F1E957 /* CanvasViewController+DocumentObserver.swift */,
 				9BC8587E1EC4F692003B3EFF /* CanvasViewController+MenuActions.swift */,
+				9BB677671ED47FB500B1AF83 /* CanvasViewController+NSPasteboard.swift */,
 			);
 			name = CanvasViewControllerExtensions;
 			sourceTree = "<group>";
@@ -466,6 +469,7 @@
 				9B521F871CFB380300A71598 /* SquareElement.swift in Sources */,
 				9B956CE51C1B11C200CF20DA /* NSPoint+Utilities.swift in Sources */,
 				9B0683FD1DA1A1AA00609AE5 /* StateManager.swift in Sources */,
+				9BB677681ED47FB500B1AF83 /* CanvasViewController+NSPasteboard.swift in Sources */,
 				9B06AD151C11AF03000BC75C /* NSView+Debugging.swift in Sources */,
 				9BD2BF3D1C7F8B6A00E8A303 /* FiniteLine.swift in Sources */,
 				9B9EC6BB1EC0E42C0048D2AC /* AreaManager.swift in Sources */,

--- a/LinkedIdeas/Base.lproj/Main.storyboard
+++ b/LinkedIdeas/Base.lproj/Main.storyboard
@@ -141,7 +141,7 @@
                                         </menuItem>
                                         <menuItem title="Copy" keyEquivalent="c" id="x3v-GG-iWU">
                                             <connections>
-                                                <action selector="copy:" target="Ady-hI-5gd" id="G1f-GL-Joy"/>
+                                                <action selector="copy:" target="Ady-hI-5gd" id="6f7-mJ-gn9"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">

--- a/LinkedIdeas/CanvasViewController+KeyboardEvents.swift
+++ b/LinkedIdeas/CanvasViewController+KeyboardEvents.swift
@@ -50,17 +50,10 @@ extension CanvasViewController {
   }
 
   func deleteKeyPressed() {
-    switch currentState {
-    case .selectedElement(let element):
-      safeTransiton {
-        try stateManager.toCanvasWaiting(deletingElements: [element])
-      }
-    case .multipleSelectedElements(let elements):
+    if let elements = selectedElements() {
       safeTransiton {
         try stateManager.toCanvasWaiting(deletingElements: elements)
       }
-    default:
-      break
     }
   }
 }

--- a/LinkedIdeas/CanvasViewController+NSPasteboard.swift
+++ b/LinkedIdeas/CanvasViewController+NSPasteboard.swift
@@ -1,0 +1,105 @@
+//
+//  CanvasViewController+NSPasteboard.swift
+//  LinkedIdeas
+//
+//  Created by Felipe Espinoza on 23/05/2017.
+//  Copyright © 2017 Felipe Espinoza Dev. All rights reserved.
+//
+
+import Cocoa
+
+extension CanvasViewController {
+  // MARK: - Pasteboard
+
+  private func writeToPasteboard(pasteboard: NSPasteboard) {
+    guard let elements = selectedElements() else {
+      return
+    }
+
+    pasteboard.clearContents()
+    pasteboard.writeObjects(elements.map { $0.attributedStringValue })
+  }
+
+  private func readFromPasteboard(pasteboard: NSPasteboard) {
+    let rawObjects = pasteboard.readObjects(
+      forClasses: [NSAttributedString.self], options: [:]
+    ) as? [NSAttributedString]
+
+    guard let objects = rawObjects, objects.count != 0 else {
+      return
+    }
+
+    pasteConcepts(fromAttributedStrings: objects)
+  }
+
+  private func readFromPasteboardAsPlainText(pasteboard: NSPasteboard) {
+    let rawObjects = pasteboard.readObjects(forClasses: [NSString.self], options: [:]) as? [String]
+
+    guard let objects = rawObjects, objects.count != 0 else {
+      return
+    }
+
+    pasteConcepts(fromAttributedStrings: objects.map { NSAttributedString(string: $0) })
+  }
+
+  private func pasteConcepts(fromAttributedStrings attributedStrings: [NSAttributedString]) {
+    safeTransiton {
+      try stateManager.toCanvasWaiting()
+    }
+
+    var newConcepts = [Concept]()
+    for (index, string) in attributedStrings.enumerated() {
+      lastCopyIndex += 1
+      let copyReferenceIndex = index + lastCopyIndex + 1
+      if let concept = createConceptFromPasteboard(attributedString: string, index: copyReferenceIndex) {
+        newConcepts.append(concept)
+      }
+    }
+
+    guard newConcepts.count > 0 else {
+      return
+    }
+
+    if newConcepts.count > 1 {
+      safeTransiton {
+        try stateManager.toMultipleSelectedElements(elements: newConcepts)
+      }
+    } else {
+      safeTransiton {
+        try stateManager.toSelectedElement(element: newConcepts.first!)
+      }
+    }
+  }
+
+  private func createConceptFromPasteboard(attributedString: NSAttributedString, index: Int) -> Concept? {
+    let newConceptPadding: Int = 15
+    let newPoint = NSPoint(
+      x: CGFloat(200 + (newConceptPadding*index)),
+      y: CGFloat(200 + (newConceptPadding*index))
+    )
+    return saveConcept(text: attributedString, atPoint: newPoint)
+  }
+
+  // MARK: - Interface actions
+
+  func cut(_ sender: Any?) {
+    writeToPasteboard(pasteboard: NSPasteboard.general())
+    if let elements = selectedElements() {
+      safeTransiton {
+        try stateManager.toCanvasWaiting(deletingElements: elements)
+      }
+    }
+  }
+
+  func copy(_ sender: Any?) {
+    writeToPasteboard(pasteboard: NSPasteboard.general())
+  }
+
+  func paste(_ sender: Any?) {
+    readFromPasteboard(pasteboard: NSPasteboard.general())
+  }
+
+  func pasteAsPlainText(_ sender: Any?) {
+    readFromPasteboardAsPlainText(pasteboard: NSPasteboard.general())
+  }
+}

--- a/LinkedIdeas/CanvasViewController.swift
+++ b/LinkedIdeas/CanvasViewController.swift
@@ -148,4 +148,17 @@ class CanvasViewController: NSViewController {
   func isDragShiftEvent(_ event: NSEvent) -> Bool {
     return event.modifierFlags.contains(.shift) || didShiftDragStart
   }
+
+  // MARK: - current State data helpers
+
+  func selectedElements() -> [Element]? {
+    switch currentState {
+    case .selectedElement(let element):
+      return [element]
+    case .multipleSelectedElements(let elements):
+      return elements
+    default:
+      return nil
+    }
+  }
 }

--- a/LinkedIdeas/CanvasViewController.swift
+++ b/LinkedIdeas/CanvasViewController.swift
@@ -14,6 +14,9 @@ class CanvasViewController: NSViewController {
 
   let textFieldResizingBehavior = TextFieldResizingBehavior()
 
+  // for handling multiple "paste" results, to move the pasting result a bit each time
+  var lastCopyIndex = 0
+
   var dragCount = 0
   var didShiftDragStart = false
   // to register the beginning of the drag


### PR DESCRIPTION
implements #38

- Add support for basic copy/cut/paste actions.
  notice that the nil-targeted actions for cut, copy and paste are not present
  in `NSResponder` then they don’t override anything.

  so they are defined just like:

  `func copy(_ sender: Any?)`

  then there is a basic copying of concepts that just copy its
  `attributedStringValue` which has direct support with the pasteboard.

  then when pasting i use the `lastCopyIndex` to slightly-translate the pasted
  elements each time.

  when pasting elements the previously selected elements will be deselected and
  the new elements that were pasted will be selected.

  in the future i can implement some custom paste support for `Concept`. Then
  it’s possible to use the copied point to locate better the next pasted
  concept.

- Use `selectedElements()` to remove unnecessary code.

- Add `CanvasViewController.selectedElements()`.
  in the states `selectedElement` and `multipleSelectedElements` there are
  references to the selected elements, and it was a common pattern to use a
  switch case on the `currentState` just to fetch this values, so created this
  function to reduce that duplication.

  plus, if no element is selected, it returns nil rather than empty array to
  make sure when this return not nil, then the array actually contains selected
  elements.