### PR TITLE
Fix: shift+enter will work when concept is selected

### DIFF
--- a/LinkedIdeas/StateManager.swift
+++ b/LinkedIdeas/StateManager.swift
@@ -92,7 +92,8 @@ struct StateManager {
   public mutating func toNewConcept(atPoint point: NSPoint) throws {
     let possibleStates: [CanvasState] = [
       .canvasWaiting,
-      .newConcept(point: NSPoint.zero)
+      .newConcept(point: NSPoint.zero),
+      .selectedElement(element: EmptyElement.example)
     ]
 
     try transition(fromPossibleStates: possibleStates, toState: .newConcept(point: point)) { (oldState) in

--- a/LinkedIdeasTests/CanvasViewControllerKeyboardTests.swift
+++ b/LinkedIdeasTests/CanvasViewControllerKeyboardTests.swift
@@ -12,6 +12,37 @@ import XCTest
 // MARK: - CanvasViewController Keyboard Based Tests
 
 extension CanvasViewControllerTests {
+  func testShiftEnterWhenCanvasIsWaiting() {
+    canvasViewController.currentState = .canvasWaiting
+
+    let enterKeyCode: UInt16 = 36
+    canvasViewController.keyDown(with: createKeyboardEvent(keyCode: enterKeyCode, shift: true))
+
+    switch canvasViewController.currentState {
+    case .newConcept:
+      break
+    default:
+      XCTFail("current state should be new Concept with random point")
+    }
+  }
+
+  func testShiftEnterWhenConceptIsSelected() {
+    let concept = Concept(stringValue: "Random", point: NSPoint(x: 20, y: 600))
+    document.concepts.append(concept)
+
+    canvasViewController.currentState = .selectedElement(element: concept)
+
+    let enterKeyCode: UInt16 = 36
+    canvasViewController.keyDown(with: createKeyboardEvent(keyCode: enterKeyCode, shift: true))
+
+    switch canvasViewController.currentState {
+    case .newConcept:
+      break
+    default:
+      XCTFail("current state should be new Concept with random point")
+    }
+  }
+
   func testTabSelectsFirstConceptOnCanvasWaiting() {
     let concepts = [
       Concept(stringValue: "Random", point: NSPoint(x: 20, y: 600)),


### PR DESCRIPTION
fixes #49

The state `.selectedElement` should be able to transition to
`.newConcept`.