### PR TITLE
CanvasView: optimize rendering

### DIFF
--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -10,6 +10,8 @@ import Cocoa
 
 public protocol CanvasViewDataSource {
   var drawableElements: [DrawableElement] { get }
+
+  func selectedDrawableElements() -> [DrawableElement]?
 }
 
 public class CanvasView: NSView {
@@ -31,13 +33,27 @@ public class CanvasView: NSView {
   var arrowStartPoint: NSPoint?
   var arrowEndPoint: NSPoint?
   var arrowColor: NSColor?
+  var firstRender: Bool = true
 
   override public func draw(_ dirtyRect: NSRect) {
     super.draw(dirtyRect)
-    drawBackground()
+//    if firstRender {
+//      drawBackground()
+//      firstRender = false
+//    } else {
 
-    if let dataSource = dataSource {
-      for element in dataSource.drawableElements { element.draw() }
+      if let dataSource = dataSource {
+        if let selectedElements = dataSource.selectedDrawableElements() {
+          for element in  selectedElements {
+            element.draw()
+          }
+        } else {
+          drawBackground()
+          for element in dataSource.drawableElements {
+            element.draw()
+          }
+        }
+//      }
     }
 
     drawSelectionRect()

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -37,7 +37,6 @@ public class CanvasView: NSView {
 
   override public func draw(_ dirtyRect: NSRect) {
     super.draw(dirtyRect)
-    Swift.print("CanvasView: draw \(dirtyRect)")
     drawBackground(dirtyRect)
     drawElements(inRect: dirtyRect)
     drawSelectionRect()
@@ -49,9 +48,7 @@ public class CanvasView: NSView {
       return
     }
 
-    let elements = dataSource.drawableElements(forRect: dirtyRect)
-    Swift.print("\(elements.count) drawn from \(dataSource.drawableElements.count)")
-    elements.forEach({ $0.draw() })
+    dataSource.drawableElements(forRect: dirtyRect).forEach({ $0.draw() })
   }
 
   func drawBackground(_ dirtyRect: NSRect) {

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -16,6 +16,10 @@ public protocol CanvasViewDataSource {
 
 public class CanvasView: NSView {
 
+  public override var isOpaque: Bool {
+    return true
+  }
+
   public var dataSource: CanvasViewDataSource?
 
   var selectFromPoint: NSPoint?

--- a/LinkedIdeas/CanvasView.swift
+++ b/LinkedIdeas/CanvasView.swift
@@ -11,15 +11,12 @@ import Cocoa
 public protocol CanvasViewDataSource {
   var drawableElements: [DrawableElement] { get }
 
-  func selectedDrawableElements() -> [DrawableElement]?
+  func drawableElements(forRect: NSRect) -> [DrawableElement]
 }
 
 public class CanvasView: NSView {
 
-  public override var isOpaque: Bool {
-    return true
-  }
-
+  public override var isOpaque: Bool { return true }
   public var dataSource: CanvasViewDataSource?
 
   var selectFromPoint: NSPoint?
@@ -37,37 +34,29 @@ public class CanvasView: NSView {
   var arrowStartPoint: NSPoint?
   var arrowEndPoint: NSPoint?
   var arrowColor: NSColor?
-  var firstRender: Bool = true
 
   override public func draw(_ dirtyRect: NSRect) {
     super.draw(dirtyRect)
-//    if firstRender {
-//      drawBackground()
-//      firstRender = false
-//    } else {
-
-      if let dataSource = dataSource {
-        if let selectedElements = dataSource.selectedDrawableElements() {
-          for element in  selectedElements {
-            element.draw()
-          }
-        } else {
-          drawBackground()
-          for element in dataSource.drawableElements {
-            element.draw()
-          }
-        }
-//      }
-    }
-
+    Swift.print("CanvasView: draw \(dirtyRect)")
+    drawBackground(dirtyRect)
+    drawElements(inRect: dirtyRect)
     drawSelectionRect()
-
     drawLinkConstructionArrow()
   }
 
-  func drawBackground() {
+  func drawElements(inRect dirtyRect: NSRect) {
+    guard let dataSource = dataSource else {
+      return
+    }
+
+    let elements = dataSource.drawableElements(forRect: dirtyRect)
+    Swift.print("\(elements.count) drawn from \(dataSource.drawableElements.count)")
+    elements.forEach({ $0.draw() })
+  }
+
+  func drawBackground(_ dirtyRect: NSRect) {
     NSColor.white.set()
-    NSRectFill(bounds)
+    NSRectFill(dirtyRect)
   }
 
   func drawSelectionRect() {
@@ -77,7 +66,6 @@ public class CanvasView: NSView {
 
     let borderColor = NSColor(red: 0, green: 0, blue: 1, alpha: 1)
     let backgroundColor = NSColor(red: 0, green: 0, blue: 1, alpha: 0.5)
-
     let bezierPath = NSBezierPath(rect: selectionRect)
 
     borderColor.set()

--- a/LinkedIdeas/CanvasViewController+CanvasViewDataSource.swift
+++ b/LinkedIdeas/CanvasViewController+CanvasViewDataSource.swift
@@ -11,6 +11,13 @@ import Foundation
 // MARK: - CanvasViewController+CanvasViewDataSource
 
 extension CanvasViewController: CanvasViewDataSource {
+  func selectedDrawableElements() -> [DrawableElement]? {
+    guard currentSelectedConcepts().count > 0 else {
+      return nil
+    }
+    return currentSelectedConcepts().map({ DrawableConcept(concept: $0) })
+  }
+
   var drawableElements: [DrawableElement] {
     var elements: [DrawableElement] = []
 

--- a/LinkedIdeas/CanvasViewController+CanvasViewDataSource.swift
+++ b/LinkedIdeas/CanvasViewController+CanvasViewDataSource.swift
@@ -11,13 +11,6 @@ import Foundation
 // MARK: - CanvasViewController+CanvasViewDataSource
 
 extension CanvasViewController: CanvasViewDataSource {
-  func selectedDrawableElements() -> [DrawableElement]? {
-    guard currentSelectedConcepts().count > 0 else {
-      return nil
-    }
-    return currentSelectedConcepts().map({ DrawableConcept(concept: $0) })
-  }
-
   var drawableElements: [DrawableElement] {
     var elements: [DrawableElement] = []
 
@@ -30,5 +23,9 @@ extension CanvasViewController: CanvasViewDataSource {
     }
 
     return elements
+  }
+
+  func drawableElements(forRect containerRect: NSRect) -> [DrawableElement] {
+    return drawableElements.filter({ containerRect.intersects($0.drawingBounds) })
   }
 }

--- a/LinkedIdeas/CanvasViewController+DraggingActions.swift
+++ b/LinkedIdeas/CanvasViewController+DraggingActions.swift
@@ -120,6 +120,6 @@ extension CanvasViewController {
     dragCount = 0
     canvasView.selectFromPoint = nil
     canvasView.selectToPoint = nil
-    canvasView.needsDisplay = true
+    reRenderCanvasView()
   }
 }

--- a/LinkedIdeas/Document.swift
+++ b/LinkedIdeas/Document.swift
@@ -194,6 +194,10 @@ extension Document: LinkedIdeasDocument {
 }
 
 extension Document: CanvasViewDataSource {
+  public func selectedDrawableElements() -> [DrawableElement]? {
+    return drawableElements
+  }
+
   public var drawableElements: [DrawableElement] {
     var elements: [DrawableElement] = []
 

--- a/LinkedIdeas/Document.swift
+++ b/LinkedIdeas/Document.swift
@@ -194,7 +194,7 @@ extension Document: LinkedIdeasDocument {
 }
 
 extension Document: CanvasViewDataSource {
-  public func selectedDrawableElements() -> [DrawableElement]? {
+  public func drawableElements(forRect: NSRect) -> [DrawableElement] {
     return drawableElements
   }
 


### PR DESCRIPTION
closes #47

Changes:
--------

- Only re-draw elements that are inside the dirtyRect.

  previously for each dirty rect I re-rendered the whole set of concepts.

- Mark view as opaque

  so the OS doesn’t need to render views under.